### PR TITLE
Support Responses API in ruby-openai 8.x+

### DIFF
--- a/lib/braintrust/trace/contrib/github.com/alexrudall/ruby-openai/ruby-openai.rb
+++ b/lib/braintrust/trace/contrib/github.com/alexrudall/ruby-openai/ruby-openai.rb
@@ -80,6 +80,28 @@ module Braintrust
               aggregated
             end
 
+            # Aggregate responses streaming chunks into a single response structure
+            # @param chunks [Array<Hash>] array of chunk hashes from stream
+            # @return [Hash] aggregated response with output, usage, id
+            def self.aggregate_responses_chunks(chunks)
+              return {} if chunks.empty?
+
+              # Find the response.completed event which has the final response
+              completed_chunk = chunks.find { |c| c["type"] == "response.completed" }
+
+              if completed_chunk && completed_chunk["response"]
+                response = completed_chunk["response"]
+                return {
+                  "id" => response["id"],
+                  "output" => response["output"],
+                  "usage" => response["usage"]
+                }
+              end
+
+              # Fallback if no completed event found
+              {}
+            end
+
             # Set span attributes from response data (works for both streaming and non-streaming)
             # @param span [OpenTelemetry::Trace::Span] the span to set attributes on
             # @param response_data [Hash] response hash with keys: choices, usage, id, created, model, system_fingerprint, service_tier
@@ -112,112 +134,235 @@ module Braintrust
             def self.wrap(client, tracer_provider: nil)
               tracer_provider ||= ::OpenTelemetry.tracer_provider
 
+              # Store tracer provider on the client for use by wrapper modules
+              client.instance_variable_set(:@braintrust_tracer_provider, tracer_provider)
+
               # Wrap chat completions
-              wrap_chat(client, tracer_provider)
+              wrap_chat(client)
+
+              # Wrap responses API if available
+              wrap_responses(client) if client.respond_to?(:responses)
 
               client
             end
 
             # Wrap chat API
             # @param client [OpenAI::Client] the OpenAI client
-            # @param tracer_provider [OpenTelemetry::SDK::Trace::TracerProvider] the tracer provider
-            def self.wrap_chat(client, tracer_provider)
-              # Capture reference to helper methods for use inside wrapper
-              ruby_openai_module = self
+            def self.wrap_chat(client)
+              client.singleton_class.prepend(ChatWrapper)
+            end
 
-              # Create a wrapper module that intercepts the chat method
-              wrapper = Module.new do
-                define_method(:chat) do |parameters:|
-                  tracer = tracer_provider.tracer("braintrust")
+            # Wrap responses API
+            # @param client [OpenAI::Client] the OpenAI client
+            def self.wrap_responses(client)
+              # Store tracer provider on the responses object for use by wrapper module
+              responses_obj = client.responses
+              responses_obj.instance_variable_set(:@braintrust_tracer_provider, client.instance_variable_get(:@braintrust_tracer_provider))
+              responses_obj.singleton_class.prepend(ResponsesCreateWrapper)
+            end
 
-                  tracer.in_span("Chat Completion") do |span|
-                    # Local helper for setting JSON attributes
-                    set_json_attr = ->(attr_name, obj) { ruby_openai_module.set_json_attr(span, attr_name, obj) }
+            # Wrapper module for chat completions
+            module ChatWrapper
+              def chat(parameters:)
+                tracer_provider = @braintrust_tracer_provider
+                tracer = tracer_provider.tracer("braintrust")
 
-                    # Track start time for time_to_first_token
-                    start_time = Time.now
-                    time_to_first_token = nil
-                    is_streaming = parameters.key?(:stream) && parameters[:stream].is_a?(Proc)
+                tracer.in_span("Chat Completion") do |span|
+                  # Track start time for time_to_first_token
+                  start_time = Time.now
+                  time_to_first_token = nil
+                  is_streaming = parameters.key?(:stream) && parameters[:stream].is_a?(Proc)
 
-                    # Initialize metadata hash
-                    metadata = {
-                      "provider" => "openai",
-                      "endpoint" => "/v1/chat/completions"
-                    }
+                  # Initialize metadata hash
+                  metadata = {
+                    "provider" => "openai",
+                    "endpoint" => "/v1/chat/completions"
+                  }
 
-                    # Capture request metadata fields
-                    metadata_fields = %w[
-                      model frequency_penalty logit_bias logprobs max_tokens n
-                      presence_penalty response_format seed service_tier stop
-                      stream stream_options temperature top_p top_logprobs
-                      tools tool_choice parallel_tool_calls user functions function_call
-                    ]
+                  # Capture request metadata fields
+                  metadata_fields = %w[
+                    model frequency_penalty logit_bias logprobs max_tokens n
+                    presence_penalty response_format seed service_tier stop
+                    stream stream_options temperature top_p top_logprobs
+                    tools tool_choice parallel_tool_calls user functions function_call
+                  ]
 
-                    metadata_fields.each do |field|
-                      field_sym = field.to_sym
-                      if parameters.key?(field_sym)
-                        # Special handling for stream parameter (it's a Proc)
-                        metadata[field] = if field == "stream"
-                          true  # Just mark as streaming
-                        else
-                          parameters[field_sym]
-                        end
-                      end
-                    end
-
-                    # Set input messages as JSON
-                    if parameters[:messages]
-                      set_json_attr.call("braintrust.input_json", parameters[:messages])
-                    end
-
-                    # Wrap streaming callback if present to capture time to first token and aggregate chunks
-                    aggregated_chunks = []
-                    if is_streaming
-                      original_stream_proc = parameters[:stream]
-                      parameters = parameters.dup
-                      parameters[:stream] = proc do |chunk, bytesize|
-                        # Capture time to first token on first chunk
-                        time_to_first_token ||= Time.now - start_time
-                        # Aggregate chunks for later processing
-                        aggregated_chunks << chunk
-                        # Call original callback
-                        original_stream_proc.call(chunk, bytesize)
-                      end
-                    end
-
-                    begin
-                      # Call the original method
-                      response = super(parameters: parameters)
-
-                      # Calculate time to first token for non-streaming
-                      time_to_first_token ||= Time.now - start_time unless is_streaming
-
-                      # Process response data
-                      if is_streaming && !aggregated_chunks.empty?
-                        # Aggregate streaming chunks into response-like structure
-                        aggregated_response = Braintrust::Trace::Contrib::Github::Alexrudall::RubyOpenAI.aggregate_streaming_chunks(aggregated_chunks)
-                        Braintrust::Trace::Contrib::Github::Alexrudall::RubyOpenAI.set_span_attributes(span, aggregated_response, time_to_first_token, metadata)
+                  metadata_fields.each do |field|
+                    field_sym = field.to_sym
+                    if parameters.key?(field_sym)
+                      # Special handling for stream parameter (it's a Proc)
+                      metadata[field] = if field == "stream"
+                        true  # Just mark as streaming
                       else
-                        # Non-streaming: use response object directly
-                        Braintrust::Trace::Contrib::Github::Alexrudall::RubyOpenAI.set_span_attributes(span, response || {}, time_to_first_token, metadata)
+                        parameters[field_sym]
                       end
-
-                      # Set metadata ONCE at the end with complete hash
-                      set_json_attr.call("braintrust.metadata", metadata)
-
-                      response
-                    rescue => e
-                      # Record exception in span
-                      span.record_exception(e)
-                      span.status = OpenTelemetry::Trace::Status.error("Exception: #{e.class} - #{e.message}")
-                      raise
                     end
+                  end
+
+                  # Set input messages as JSON
+                  if parameters[:messages]
+                    RubyOpenAI.set_json_attr(span, "braintrust.input_json", parameters[:messages])
+                  end
+
+                  # Wrap streaming callback if present to capture time to first token and aggregate chunks
+                  aggregated_chunks = []
+                  if is_streaming
+                    original_stream_proc = parameters[:stream]
+                    parameters = parameters.dup
+                    parameters[:stream] = proc do |chunk, bytesize|
+                      # Capture time to first token on first chunk
+                      time_to_first_token ||= Time.now - start_time
+                      # Aggregate chunks for later processing
+                      aggregated_chunks << chunk
+                      # Call original callback
+                      original_stream_proc.call(chunk, bytesize)
+                    end
+                  end
+
+                  begin
+                    # Call the original method
+                    response = super(parameters: parameters)
+
+                    # Calculate time to first token for non-streaming
+                    time_to_first_token ||= Time.now - start_time unless is_streaming
+
+                    # Process response data
+                    if is_streaming && !aggregated_chunks.empty?
+                      # Aggregate streaming chunks into response-like structure
+                      aggregated_response = RubyOpenAI.aggregate_streaming_chunks(aggregated_chunks)
+                      RubyOpenAI.set_span_attributes(span, aggregated_response, time_to_first_token, metadata)
+                    else
+                      # Non-streaming: use response object directly
+                      RubyOpenAI.set_span_attributes(span, response || {}, time_to_first_token, metadata)
+                    end
+
+                    # Set metadata ONCE at the end with complete hash
+                    RubyOpenAI.set_json_attr(span, "braintrust.metadata", metadata)
+
+                    response
+                  rescue => e
+                    # Record exception in span
+                    span.record_exception(e)
+                    span.status = OpenTelemetry::Trace::Status.error("Exception: #{e.class} - #{e.message}")
+                    raise
                   end
                 end
               end
+            end
 
-              # Prepend the wrapper to the client's singleton class
-              client.singleton_class.prepend(wrapper)
+            # Wrapper module for responses API create method
+            module ResponsesCreateWrapper
+              def create(parameters:)
+                tracer_provider = @braintrust_tracer_provider
+                tracer = tracer_provider.tracer("braintrust")
+
+                tracer.in_span("openai.responses.create") do |span|
+                  # Track start time for time_to_first_token
+                  start_time = Time.now
+                  time_to_first_token = nil
+                  is_streaming = parameters.key?(:stream) && parameters[:stream].is_a?(Proc)
+
+                  # Initialize metadata hash
+                  metadata = {
+                    "provider" => "openai",
+                    "endpoint" => "/v1/responses"
+                  }
+
+                  # Capture request metadata fields
+                  metadata_fields = %w[
+                    model instructions modalities tools parallel_tool_calls
+                    tool_choice temperature max_tokens top_p frequency_penalty
+                    presence_penalty seed user store response_format
+                    reasoning previous_response_id truncation
+                  ]
+
+                  metadata_fields.each do |field|
+                    field_sym = field.to_sym
+                    if parameters.key?(field_sym)
+                      metadata[field] = parameters[field_sym]
+                    end
+                  end
+
+                  # Mark as streaming if applicable
+                  metadata["stream"] = true if is_streaming
+
+                  # Set input as JSON
+                  if parameters[:input]
+                    RubyOpenAI.set_json_attr(span, "braintrust.input_json", parameters[:input])
+                  end
+
+                  # Wrap streaming callback if present to capture time to first token and aggregate chunks
+                  aggregated_chunks = []
+                  if is_streaming
+                    original_stream_proc = parameters[:stream]
+                    parameters = parameters.dup
+                    parameters[:stream] = proc do |chunk, event|
+                      # Capture time to first token on first chunk
+                      time_to_first_token ||= Time.now - start_time
+                      # Aggregate chunks for later processing
+                      aggregated_chunks << chunk
+                      # Call original callback
+                      original_stream_proc.call(chunk, event)
+                    end
+                  end
+
+                  begin
+                    # Call the original method
+                    response = super(parameters: parameters)
+
+                    # Calculate time to first token for non-streaming
+                    time_to_first_token ||= Time.now - start_time unless is_streaming
+
+                    # Process response data
+                    if is_streaming && !aggregated_chunks.empty?
+                      # Aggregate streaming chunks into response-like structure
+                      aggregated_response = RubyOpenAI.aggregate_responses_chunks(aggregated_chunks)
+
+                      # Set output as JSON
+                      if aggregated_response["output"]
+                        RubyOpenAI.set_json_attr(span, "braintrust.output_json", aggregated_response["output"])
+                      end
+
+                      # Set metrics (token usage + time_to_first_token)
+                      metrics = {}
+                      if aggregated_response["usage"]
+                        metrics = RubyOpenAI.parse_usage_tokens(aggregated_response["usage"])
+                      end
+                      metrics["time_to_first_token"] = time_to_first_token || 0.0
+                      RubyOpenAI.set_json_attr(span, "braintrust.metrics", metrics) unless metrics.empty?
+
+                      # Update metadata with response fields
+                      metadata["id"] = aggregated_response["id"] if aggregated_response["id"]
+                    else
+                      # Non-streaming: use response object directly
+                      if response && response["output"]
+                        RubyOpenAI.set_json_attr(span, "braintrust.output_json", response["output"])
+                      end
+
+                      # Set metrics (token usage + time_to_first_token)
+                      metrics = {}
+                      if response && response["usage"]
+                        metrics = RubyOpenAI.parse_usage_tokens(response["usage"])
+                      end
+                      metrics["time_to_first_token"] = time_to_first_token || 0.0
+                      RubyOpenAI.set_json_attr(span, "braintrust.metrics", metrics) unless metrics.empty?
+
+                      # Update metadata with response fields
+                      metadata["id"] = response["id"] if response && response["id"]
+                    end
+
+                    # Set metadata ONCE at the end with complete hash
+                    RubyOpenAI.set_json_attr(span, "braintrust.metadata", metadata)
+
+                    response
+                  rescue => e
+                    # Record exception in span
+                    span.record_exception(e)
+                    span.status = OpenTelemetry::Trace::Status.error("Exception: #{e.class} - #{e.message}")
+                    raise
+                  end
+                end
+              end
             end
           end
         end

--- a/lib/braintrust/trace/tokens.rb
+++ b/lib/braintrust/trace/tokens.rb
@@ -14,16 +14,24 @@ module Braintrust
       return metrics unless usage_hash.is_a?(Hash)
 
       # Field mappings: OpenAI → Braintrust
+      # Supports both Chat Completions API (prompt_tokens, completion_tokens)
+      # and Responses API (input_tokens, output_tokens)
       field_map = {
         "prompt_tokens" => "prompt_tokens",
         "completion_tokens" => "completion_tokens",
-        "total_tokens" => "tokens"
+        "total_tokens" => "tokens",
+        # Responses API uses different field names
+        "input_tokens" => "prompt_tokens",
+        "output_tokens" => "completion_tokens"
       }
 
       # Prefix mappings for *_tokens_details
       prefix_map = {
         "prompt" => "prompt",
-        "completion" => "completion"
+        "completion" => "completion",
+        # Responses API uses input/output prefixes
+        "input" => "prompt",
+        "output" => "completion"
       }
 
       usage_hash.each do |key, value|

--- a/test/fixtures/vcr_cassettes/alexrudall_ruby_openai/responses_error.yml
+++ b/test/fixtures/vcr_cassettes/alexrudall_ruby_openai/responses_error.yml
@@ -1,0 +1,73 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","input":"test"}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer invalid_key
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Date:
+      - Mon, 08 Dec 2025 20:05:24 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '240'
+      Connection:
+      - keep-alive
+      Www-Authenticate:
+      - Bearer realm="OpenAI API"
+      Openai-Version:
+      - '2020-10-01'
+      X-Request-Id:
+      - req_00e1a079c9134219ad7a4d6363fae880
+      Openai-Processing-Ms:
+      - '33'
+      X-Envoy-Upstream-Service-Time:
+      - '36'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=W2rnUPcqYCODRDPrmmn6pKgMa9h3X4SBA.qMrtHy910-1765224324-1.0.1.1-mcrJuPLn3qMGxo1NZBfPky6gOeDyVwNVThwbxPkepxrba6L9peve.gWepOApH0mn66fhxPtmknkxW5qa5eNM9iqQX9LSdnglgQKUc_Htp1M;
+        path=/; expires=Mon, 08-Dec-25 20:35:24 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=2rWpZqt_rQkwWt0SCRlA7m7gTFM7E8F0I0u_seSuA1s-1765224324360-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9aaee09a5caa5008-IAD
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |-
+        {
+          "error": {
+            "message": "Incorrect API key provided: invalid_key. You can find your API key at https://platform.openai.com/account/api-keys.",
+            "type": "invalid_request_error",
+            "param": null,
+            "code": "invalid_api_key"
+          }
+        }
+  recorded_at: Mon, 08 Dec 2025 20:05:24 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/alexrudall_ruby_openai/responses_non_streaming.yml
+++ b/test/fixtures/vcr_cassettes/alexrudall_ruby_openai/responses_non_streaming.yml
@@ -1,0 +1,147 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","input":"What is 2+2? Reply with just the number."}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Dec 2025 20:05:30 GMT
+      Content-Type:
+      - application/json
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      X-Ratelimit-Limit-Requests:
+      - '200'
+      X-Ratelimit-Limit-Tokens:
+      - '100000'
+      X-Ratelimit-Remaining-Requests:
+      - '198'
+      X-Ratelimit-Remaining-Tokens:
+      - '99611'
+      X-Ratelimit-Reset-Requests:
+      - 14m20.852s
+      X-Ratelimit-Reset-Tokens:
+      - 2h47m48.417s
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-ehotg7f6lk20ot29mnwkdime
+      Openai-Project:
+      - proj_qkNVwAL12pw1UayHomnm5oBd
+      X-Request-Id:
+      - req_871b07286c2b42358b69120f635d464a
+      Openai-Processing-Ms:
+      - '2152'
+      X-Envoy-Upstream-Service-Time:
+      - '2154'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=pV_Y38So_b_gZV759oqUpcbxAhzA8ksn.v9zG7_cKvI-1765224330-1.0.1.1-Ndj15dXQI.AZhMxfCOOpeEJl.UUWnjcPtL6Ygz9F7P1D5aH6.MpNkYednPfAi.wStoTtQRuLgks21q3Q2vNp2_J9.yPRbzYvdB8Ka_QDjgA;
+        path=/; expires=Mon, 08-Dec-25 20:35:30 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=U4LUZ3YbjKdN5RpVMWhH42VoDo7cjBTDTlv99PLFx1E-1765224330144-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9aaee0ad0d2e6fbc-IAD
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: ASCII-8BIT
+      string: |-
+        {
+          "id": "resp_0f49a2d0e5b190d50069372f87fc708196ace42359ad61d0bb",
+          "object": "response",
+          "created_at": 1765224328,
+          "status": "completed",
+          "background": false,
+          "billing": {
+            "payer": "developer"
+          },
+          "error": null,
+          "incomplete_details": null,
+          "instructions": null,
+          "max_output_tokens": null,
+          "max_tool_calls": null,
+          "model": "gpt-4o-mini-2024-07-18",
+          "output": [
+            {
+              "id": "msg_0f49a2d0e5b190d50069372f88c4fc81968323478f95e1097c",
+              "type": "message",
+              "status": "completed",
+              "content": [
+                {
+                  "type": "output_text",
+                  "annotations": [],
+                  "logprobs": [],
+                  "text": "4"
+                }
+              ],
+              "role": "assistant"
+            }
+          ],
+          "parallel_tool_calls": true,
+          "previous_response_id": null,
+          "prompt_cache_key": null,
+          "prompt_cache_retention": null,
+          "reasoning": {
+            "effort": null,
+            "summary": null
+          },
+          "safety_identifier": null,
+          "service_tier": "default",
+          "store": true,
+          "temperature": 1.0,
+          "text": {
+            "format": {
+              "type": "text"
+            },
+            "verbosity": "medium"
+          },
+          "tool_choice": "auto",
+          "tools": [],
+          "top_logprobs": 0,
+          "top_p": 1.0,
+          "truncation": "disabled",
+          "usage": {
+            "input_tokens": 20,
+            "input_tokens_details": {
+              "cached_tokens": 0
+            },
+            "output_tokens": 2,
+            "output_tokens_details": {
+              "reasoning_tokens": 0
+            },
+            "total_tokens": 22
+          },
+          "user": null,
+          "metadata": {}
+        }
+  recorded_at: Mon, 08 Dec 2025 20:05:30 GMT
+recorded_with: VCR 6.3.1

--- a/test/fixtures/vcr_cassettes/alexrudall_ruby_openai/responses_streaming.yml
+++ b/test/fixtures/vcr_cassettes/alexrudall_ruby_openai/responses_streaming.yml
@@ -1,0 +1,115 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.openai.com/v1/responses
+    body:
+      encoding: UTF-8
+      string: '{"model":"gpt-4o-mini","input":"Count from 1 to 3","stream":true}'
+    headers:
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <OPENAI_API_KEY>
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Mon, 08 Dec 2025 20:05:24 GMT
+      Content-Type:
+      - text/event-stream; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - keep-alive
+      Openai-Version:
+      - '2020-10-01'
+      Openai-Organization:
+      - user-ehotg7f6lk20ot29mnwkdime
+      Openai-Project:
+      - proj_qkNVwAL12pw1UayHomnm5oBd
+      X-Request-Id:
+      - req_14f0b1322c114bd6ab35d319b487ba87
+      Openai-Processing-Ms:
+      - '32'
+      X-Envoy-Upstream-Service-Time:
+      - '39'
+      Cf-Cache-Status:
+      - DYNAMIC
+      Set-Cookie:
+      - __cf_bm=wmeyolF7Vs_H5AFL2e9TxCtoGbFxfSn0Zd9SvaGLqzE-1765224324-1.0.1.1-sVrKxHEYwDtb9oQUB7GYpsAkdRKVGgZfjLR_yquF_aMRj6AvAcjoVmDezADGYHzcs_Fo6rYbXMVykzFwFz6HVNMMqr_nMgUS.m0bl83814g;
+        path=/; expires=Mon, 08-Dec-25 20:35:24 GMT; domain=.api.openai.com; HttpOnly;
+        Secure; SameSite=None
+      - _cfuvid=g1Nsly0tM8dgBZdmgU9XUuWIKINVRbYWs.1FLL15HeA-1765224324935-0.0.1.1-604800000;
+        path=/; domain=.api.openai.com; HttpOnly; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Server:
+      - cloudflare
+      Cf-Ray:
+      - 9aaee09c0ec182b7-IAD
+      Alt-Svc:
+      - h3=":443"; ma=86400
+    body:
+      encoding: UTF-8
+      string: |+
+        event: response.created
+        data: {"type":"response.created","sequence_number":0,"response":{"id":"resp_03bc4bb2774ae3630069372f84ea08819f941b83c54bf897a9","object":"response","created_at":1765224324,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+        event: response.in_progress
+        data: {"type":"response.in_progress","sequence_number":1,"response":{"id":"resp_03bc4bb2774ae3630069372f84ea08819f941b83c54bf897a9","object":"response","created_at":1765224324,"status":"in_progress","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"auto","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":null,"user":null,"metadata":{}}}
+
+        event: response.output_item.added
+        data: {"type":"response.output_item.added","sequence_number":2,"output_index":0,"item":{"id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","type":"message","status":"in_progress","content":[],"role":"assistant"}}
+
+        event: response.content_part.added
+        data: {"type":"response.content_part.added","sequence_number":3,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":""}}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":4,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":"1","logprobs":[],"obfuscation":"IaazzYhjoEEg6Ce"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":5,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"wQS6ZqFR2oIYxkX"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":6,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":" ","logprobs":[],"obfuscation":"fPOMlFFXkaFPj3A"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":7,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":"2","logprobs":[],"obfuscation":"NvoIoV9xgF4spdJ"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":8,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":",","logprobs":[],"obfuscation":"WTnYkJyyjB8QPmc"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":9,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":" ","logprobs":[],"obfuscation":"z6WpbrrXqJJ7EOe"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":10,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":"3","logprobs":[],"obfuscation":"Ot70X15LzHZ2aTc"}
+
+        event: response.output_text.delta
+        data: {"type":"response.output_text.delta","sequence_number":11,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"delta":".","logprobs":[],"obfuscation":"XJmD6iv7BoUVo6f"}
+
+        event: response.output_text.done
+        data: {"type":"response.output_text.done","sequence_number":12,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"text":"1, 2, 3.","logprobs":[]}
+
+        event: response.content_part.done
+        data: {"type":"response.content_part.done","sequence_number":13,"item_id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","output_index":0,"content_index":0,"part":{"type":"output_text","annotations":[],"logprobs":[],"text":"1, 2, 3."}}
+
+        event: response.output_item.done
+        data: {"type":"response.output_item.done","sequence_number":14,"output_index":0,"item":{"id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"1, 2, 3."}],"role":"assistant"}}
+
+        event: response.completed
+        data: {"type":"response.completed","sequence_number":15,"response":{"id":"resp_03bc4bb2774ae3630069372f84ea08819f941b83c54bf897a9","object":"response","created_at":1765224324,"status":"completed","background":false,"error":null,"incomplete_details":null,"instructions":null,"max_output_tokens":null,"max_tool_calls":null,"model":"gpt-4o-mini-2024-07-18","output":[{"id":"msg_03bc4bb2774ae3630069372f857d78819fb5bef18a23036055","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"logprobs":[],"text":"1, 2, 3."}],"role":"assistant"}],"parallel_tool_calls":true,"previous_response_id":null,"prompt_cache_key":null,"prompt_cache_retention":null,"reasoning":{"effort":null,"summary":null},"safety_identifier":null,"service_tier":"default","store":true,"temperature":1.0,"text":{"format":{"type":"text"},"verbosity":"medium"},"tool_choice":"auto","tools":[],"top_logprobs":0,"top_p":1.0,"truncation":"disabled","usage":{"input_tokens":14,"input_tokens_details":{"cached_tokens":0},"output_tokens":9,"output_tokens_details":{"reasoning_tokens":0},"total_tokens":23},"user":null,"metadata":{}}}
+
+  recorded_at: Mon, 08 Dec 2025 20:05:26 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
The `ruby-openai` 8.x gem added a new Responses API to mirror the OpenAI SDK. This pull request adds support for instrumenting these requests as a part of existing `ruby-openai` instrumentation.

Some things of note:

- Responses API does NOT exist in versions earlier than 8.x, so 8.x+ is required.
- It includes tests and some internal examples to try this feature with.
- It includes a minor but important refactor: changing the existing `ruby-openai` instrumentation to use a statically defined module  instead of dynamically creating and prepending one. This may prevent a double instrumentation bug if a user's application were ever to apply the wrapper to the same client twice.
    - I'd recommend another refactor of patching the class instead of the `singleton_class` in the future: this reduces performance cost and would capture all instances of `ruby-openai` clients. Further investigation/effort is needed though.
    
 Addresses https://github.com/braintrustdata/braintrust-sdk-ruby/issues/43