### PR TITLE
Simplify the Eval.run logic by encapsulating execution in a Runner class

### DIFF
--- a/lib/braintrust/eval/runner.rb
+++ b/lib/braintrust/eval/runner.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require_relative "case"
+require_relative "cases"
+require_relative "scorer"
+require_relative "result"
+require_relative "../internal/thread_pool"
+
+require "opentelemetry/sdk"
+require "json"
+
+module Braintrust
+  module Eval
+    # Internal runner class that performs the execution of the Eval and returns the result
+    class Runner
+      # Maximum parallelism allowed (mirrors Internal::ThreadPool::MAX_PARALLELISM)
+      MAX_PARALLELISM = Internal::ThreadPool::MAX_PARALLELISM
+
+      def initialize(experiment_id:, experiment_name:, project_id:, project_name:,
+        task:, scorers:, state:, tracer_provider: nil)
+        @experiment_id = experiment_id
+        @experiment_name = experiment_name
+        @project_id = project_id
+        @project_name = project_name
+        @task = task
+        @scorers = normalize_scorers(scorers)
+        @state = state
+        @tracer_provider = tracer_provider || OpenTelemetry.tracer_provider
+        @tracer = @tracer_provider.tracer("braintrust-eval")
+        @parent_attr = "experiment_id:#{experiment_id}"
+      end
+
+      # Run evaluation and return Result
+      # @param cases [Array, Enumerable] Test cases
+      # @param parallelism [Integer] Number of parallel workers (default: 1)
+      # @return [Result]
+      def run(cases, parallelism: 1)
+        start_time = Time.now
+        normalized_cases = normalize_cases(cases)
+        errors = Queue.new
+
+        if parallelism && parallelism > 1
+          Internal::ThreadPool.each(normalized_cases, parallelism: parallelism) do |test_case|
+            run_case(test_case, errors)
+          end
+        else
+          normalized_cases.each do |test_case|
+            run_case(test_case, errors)
+          end
+        end
+
+        # Convert Queue to Array after all threads complete
+        error_array = [].tap { |a| a << errors.pop until errors.empty? }
+
+        # Calculate duration
+        duration = Time.now - start_time
+
+        # Generate permalink
+        permalink = "#{state.app_url}/app/#{state.org_name}/object?object_type=experiment&object_id=#{experiment_id}"
+
+        Result.new(
+          experiment_id: experiment_id,
+          experiment_name: experiment_name,
+          project_id: project_id,
+          project_name: project_name,
+          permalink: permalink,
+          errors: error_array,
+          duration: duration
+        )
+      end
+
+      private
+
+      attr_reader :experiment_id, :experiment_name, :project_id, :project_name,
+        :task, :scorers, :state, :tracer, :parent_attr
+
+      # Run a single test case with OpenTelemetry tracing
+      # Creates eval span (parent) with task and score as children
+      # @param test_case [Case] The test case
+      # @param errors [Queue] Thread-safe error collection queue
+      def run_case(test_case, errors)
+        tracer.in_span("eval") do |eval_span|
+          eval_span.set_attribute("braintrust.parent", parent_attr)
+
+          # Set tags early so they're present even if task fails
+          eval_span.set_attribute("braintrust.tags", test_case.tags) if test_case.tags
+
+          # Run task
+          output = nil
+          begin
+            output = run_task(test_case)
+          rescue => e
+            # Error already recorded on task span, set eval span status
+            eval_span.status = OpenTelemetry::Trace::Status.error(e.message)
+            errors << "Task failed for input '#{test_case.input}': #{e.message}"
+            next
+          end
+
+          # Run scorers
+          begin
+            run_scorers(test_case, output)
+          rescue => e
+            # Error already recorded on score span, set eval span status
+            eval_span.status = OpenTelemetry::Trace::Status.error(e.message)
+            errors << "Scorers failed for input '#{test_case.input}': #{e.message}"
+          end
+
+          # Set eval span attributes (after task and scorers complete)
+          set_json_attr(eval_span, "braintrust.span_attributes", {type: "eval"})
+          set_json_attr(eval_span, "braintrust.input_json", test_case.input)
+          set_json_attr(eval_span, "braintrust.output_json", output)
+          set_json_attr(eval_span, "braintrust.expected", test_case.expected) if test_case.expected
+        end
+      end
+
+      # Run task with OpenTelemetry tracing
+      # Creates task span with input and output
+      # @param test_case [Case] The test case
+      # @return [Object] Task output
+      def run_task(test_case)
+        tracer.in_span("task") do |task_span|
+          task_span.set_attribute("braintrust.parent", parent_attr)
+          set_json_attr(task_span, "braintrust.span_attributes", {type: "task"})
+          set_json_attr(task_span, "braintrust.input_json", test_case.input)
+
+          begin
+            output = task.call(test_case.input)
+            set_json_attr(task_span, "braintrust.output_json", output)
+            output
+          rescue => e
+            # Record exception event with stacktrace, then set error status
+            task_span.record_exception(e)
+            task_span.status = OpenTelemetry::Trace::Status.error(e.message)
+            raise
+          end
+        end
+      end
+
+      # Run scorers with OpenTelemetry tracing
+      # Creates single score span for all scorers
+      # @param test_case [Case] The test case
+      # @param output [Object] Task output
+      def run_scorers(test_case, output)
+        tracer.in_span("score") do |score_span|
+          score_span.set_attribute("braintrust.parent", parent_attr)
+          set_json_attr(score_span, "braintrust.span_attributes", {type: "score"})
+
+          scores = {}
+          scorer_error = nil
+          scorers.each do |scorer|
+            score_value = scorer.call(test_case.input, test_case.expected, output, test_case.metadata || {})
+            scores[scorer.name] = score_value
+          rescue => e
+            # Record first error but continue processing other scorers
+            scorer_error ||= "Scorer '#{scorer.name}' failed: #{e.message}"
+            record_span_error(score_span, e, "ScorerError")
+          end
+
+          # Always set scores attribute, even if some scorers failed
+          set_json_attr(score_span, "braintrust.scores", scores)
+
+          # Raise after setting scores so we can see which scorers succeeded
+          raise scorer_error if scorer_error
+        end
+      end
+
+      # Normalize cases input to Cases wrapper
+      # @param cases_input [Array, Enumerable, Cases] The cases input
+      # @return [Cases]
+      def normalize_cases(cases_input)
+        case cases_input
+        when Cases
+          cases_input
+        when Array, Enumerable
+          Cases.new(cases_input)
+        else
+          if cases_input.respond_to?(:each)
+            Cases.new(cases_input)
+          else
+            raise ArgumentError, "cases must be Array or Enumerable"
+          end
+        end
+      end
+
+      # Normalize scorers to Scorer objects
+      # @param scorers_input [Array] The scorers input (Scorer objects or callables)
+      # @return [Array<Scorer>]
+      def normalize_scorers(scorers_input)
+        scorers_input.map do |scorer|
+          case scorer
+          when Scorer
+            scorer
+          else
+            Scorer.new(scorer)
+          end
+        end
+      end
+
+      # Record error on span with exception event and error status
+      # @param span [OpenTelemetry::Trace::Span] The span to record error on
+      # @param error [Exception] The error that occurred
+      # @param error_type [String] The error type name (optional)
+      def record_span_error(span, error, error_type = nil)
+        if error_type
+          span.record_exception(error, attributes: {"exception.type" => error_type})
+        else
+          span.record_exception(error)
+        end
+        span.status = OpenTelemetry::Trace::Status.error(error.message)
+      end
+
+      # Set a span attribute by JSON encoding the value
+      # @param span [OpenTelemetry::Trace::Span] The span
+      # @param key [String] The attribute key
+      # @param value [Object] The value to JSON encode
+      def set_json_attr(span, key, value)
+        span.set_attribute(key, JSON.dump(value))
+      end
+    end
+  end
+end

--- a/test/braintrust/eval_test.rb
+++ b/test/braintrust/eval_test.rb
@@ -681,7 +681,7 @@ class Braintrust::EvalTest < Minitest::Test
     task = ->(input) { input.upcase }
     scorer = Braintrust::Eval.scorer("exact") { |i, e, o| (o == e) ? 1.0 : 0.0 }
 
-    max_parallelism = Braintrust::Eval::MAX_PARALLELISM
+    max_parallelism = Braintrust::Eval::Runner::MAX_PARALLELISM
     error = assert_raises(ArgumentError) do
       run_test_eval(
         experiment_id: "test-exp-123",
@@ -749,5 +749,559 @@ class Braintrust::EvalTest < Minitest::Test
     )
     assert result.success?
     assert_equal %w[a b], order
+  end
+end
+
+# Unit tests for Eval::Runner class
+class Braintrust::Eval::RunnerTest < Minitest::Test
+  # Define a method-based scorer for tests
+  def exact_match_scorer(input, expected, output, metadata = {})
+    (output == expected) ? 1.0 : 0.0
+  end
+
+  # ============================================
+  # Runner#run tests - basic functionality
+  # ============================================
+
+  def test_runner_run_returns_result_object
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| (o == e) ? 1.0 : 0.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([{input: "hello", expected: "HELLO"}])
+
+    assert_instance_of Braintrust::Eval::Result, result
+  end
+
+  def test_runner_run_populates_result_fields
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([{input: "hello", expected: "HELLO"}])
+
+    assert_equal "exp-123", result.experiment_id
+    assert_equal "test-experiment", result.experiment_name
+    assert_equal "proj-456", result.project_id
+    assert_equal "test-project", result.project_name
+    assert result.duration > 0
+    assert_empty result.errors
+    assert result.success?
+  end
+
+  def test_runner_run_generates_correct_permalink
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-abc-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input },
+      scorers: [Braintrust::Eval.scorer("test") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([{input: "test"}])
+
+    expected_permalink = "#{rig.state.app_url}/app/#{rig.state.org_name}/object?object_type=experiment&object_id=exp-abc-123"
+    assert_equal expected_permalink, result.permalink
+  end
+
+  def test_runner_run_executes_task_for_each_case
+    rig = setup_otel_test_rig
+    executed_inputs = []
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        executed_inputs << input
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    runner.run([
+      {input: "a", expected: "A"},
+      {input: "b", expected: "B"},
+      {input: "c", expected: "C"}
+    ])
+
+    assert_equal %w[a b c], executed_inputs
+  end
+
+  def test_runner_run_executes_scorers_with_correct_args
+    rig = setup_otel_test_rig
+    scorer_calls = []
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [
+        Braintrust::Eval.scorer("recorder") { |input, expected, output, metadata|
+          scorer_calls << {input: input, expected: expected, output: output, metadata: metadata}
+          1.0
+        }
+      ],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    runner.run([
+      {input: "hello", expected: "HELLO", metadata: {key: "value"}}
+    ])
+
+    assert_equal 1, scorer_calls.length
+    assert_equal "hello", scorer_calls[0][:input]
+    assert_equal "HELLO", scorer_calls[0][:expected]
+    assert_equal "HELLO", scorer_calls[0][:output]
+    assert_equal({key: "value"}, scorer_calls[0][:metadata])
+  end
+
+  # ============================================
+  # Runner#run tests - cases normalization
+  # ============================================
+
+  def test_runner_run_accepts_array_of_hashes
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input },
+      scorers: [Braintrust::Eval.scorer("test") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([{input: "a"}, {input: "b"}])
+    assert result.success?
+  end
+
+  def test_runner_run_accepts_cases_object
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input },
+      scorers: [Braintrust::Eval.scorer("test") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    cases = Braintrust::Eval::Cases.new([{input: "test"}])
+    result = runner.run(cases)
+    assert result.success?
+  end
+
+  def test_runner_run_accepts_enumerable
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input },
+      scorers: [Braintrust::Eval.scorer("test") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    # Use an Enumerator
+    enum = [{input: "a"}, {input: "b"}].each
+    result = runner.run(enum)
+    assert result.success?
+  end
+
+  # ============================================
+  # Runner#run tests - error handling
+  # ============================================
+
+  def test_runner_run_collects_task_errors
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        raise "Task error!" if input == "bad"
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([
+      {input: "good", expected: "GOOD"},
+      {input: "bad", expected: "BAD"}
+    ])
+
+    assert result.failed?
+    assert_equal 1, result.errors.length
+    assert_match(/Task failed for input 'bad'/, result.errors[0])
+    assert_match(/Task error!/, result.errors[0])
+  end
+
+  def test_runner_run_collects_scorer_errors
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [
+        Braintrust::Eval.scorer("failing") { |i, e, o|
+          raise "Scorer error!" if i == "bad"
+          1.0
+        }
+      ],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([
+      {input: "good", expected: "GOOD"},
+      {input: "bad", expected: "BAD"}
+    ])
+
+    assert result.failed?
+    assert_equal 1, result.errors.length
+    assert_match(/Scorers failed for input 'bad'/, result.errors[0])
+  end
+
+  def test_runner_run_continues_after_task_error
+    rig = setup_otel_test_rig
+    executed = []
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        executed << input
+        raise "Error!" if input == "b"
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([
+      {input: "a"},
+      {input: "b"},
+      {input: "c"}
+    ])
+
+    # All cases should be executed despite error on "b"
+    assert_equal %w[a b c], executed
+    assert_equal 1, result.errors.length
+  end
+
+  def test_runner_run_collects_multiple_errors
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        raise "Error for #{input}" if input.start_with?("bad")
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([
+      {input: "good"},
+      {input: "bad1"},
+      {input: "bad2"}
+    ])
+
+    assert result.failed?
+    assert_equal 2, result.errors.length
+  end
+
+  # ============================================
+  # Runner#run tests - parallelism
+  # ============================================
+
+  def test_runner_run_with_parallelism_greater_than_1
+    rig = setup_otel_test_rig
+    executed = Queue.new
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        executed << input
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = runner.run([
+      {input: "a"},
+      {input: "b"},
+      {input: "c"},
+      {input: "d"}
+    ], parallelism: 3)
+
+    assert result.success?
+    assert_equal 4, executed.size
+  end
+
+  def test_runner_run_sequential_preserves_order
+    rig = setup_otel_test_rig
+    order = []
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        order << input
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    runner.run([
+      {input: "a"},
+      {input: "b"},
+      {input: "c"}
+    ], parallelism: 1)
+
+    assert_equal %w[a b c], order
+  end
+
+  def test_runner_run_default_parallelism_is_sequential
+    rig = setup_otel_test_rig
+    order = []
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        order << input
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    # Don't pass parallelism, should default to 1 (sequential)
+    runner.run([{input: "a"}, {input: "b"}, {input: "c"}])
+
+    assert_equal %w[a b c], order
+  end
+
+  # ============================================
+  # Runner#run tests - OpenTelemetry spans
+  # ============================================
+
+  def test_runner_run_creates_eval_spans
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    runner.run([{input: "hello", expected: "HELLO"}])
+
+    spans = rig.exporter.finished_spans
+    eval_spans = spans.select { |s| s.name == "eval" }
+
+    assert_equal 1, eval_spans.length
+    assert_equal "experiment_id:exp-123", eval_spans[0].attributes["braintrust.parent"]
+  end
+
+  def test_runner_run_creates_task_spans
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    runner.run([{input: "hello", expected: "HELLO"}])
+
+    spans = rig.exporter.finished_spans
+    task_spans = spans.select { |s| s.name == "task" }
+
+    assert_equal 1, task_spans.length
+    assert_equal "experiment_id:exp-123", task_spans[0].attributes["braintrust.parent"]
+  end
+
+  def test_runner_run_creates_score_spans
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    runner.run([{input: "hello", expected: "HELLO"}])
+
+    spans = rig.exporter.finished_spans
+    score_spans = spans.select { |s| s.name == "score" }
+
+    assert_equal 1, score_spans.length
+    assert_equal "experiment_id:exp-123", score_spans[0].attributes["braintrust.parent"]
+  end
+
+  def test_runner_run_records_scores_on_span
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) { input.upcase },
+      scorers: [
+        Braintrust::Eval.scorer("accuracy") { |i, e, o| 0.95 },
+        Braintrust::Eval.scorer("relevance") { |i, e, o| 0.87 }
+      ],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    runner.run([{input: "hello", expected: "HELLO"}])
+
+    spans = rig.exporter.finished_spans
+    score_span = spans.find { |s| s.name == "score" }
+
+    scores = JSON.parse(score_span.attributes["braintrust.scores"])
+    assert_equal 0.95, scores["accuracy"]
+    assert_equal 0.87, scores["relevance"]
+  end
+
+  # ============================================
+  # Runner reusability tests
+  # ============================================
+
+  def test_runner_can_be_run_multiple_times
+    rig = setup_otel_test_rig
+    call_count = 0
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        call_count += 1
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result1 = runner.run([{input: "a"}])
+    result2 = runner.run([{input: "b"}, {input: "c"}])
+
+    assert result1.success?
+    assert result2.success?
+    assert_equal 3, call_count
+  end
+
+  def test_runner_runs_are_independent
+    rig = setup_otel_test_rig
+
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: "exp-123",
+      experiment_name: "test-experiment",
+      project_id: "proj-456",
+      project_name: "test-project",
+      task: ->(input) {
+        raise "Error!" if input == "bad"
+        input.upcase
+      },
+      scorers: [Braintrust::Eval.scorer("exact") { |i, e, o| 1.0 }],
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    # First run has an error
+    result1 = runner.run([{input: "bad"}])
+    assert result1.failed?
+
+    # Second run should be independent (no errors from first run)
+    result2 = runner.run([{input: "good"}])
+    assert result2.success?
+    assert_empty result2.errors
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -150,10 +150,19 @@ module TracingTestHelper
   end
 
   # Helper to run eval internally without API calls for testing
-  # Wraps the private run_internal method
-  def run_test_eval(**kwargs)
-    kwargs[:parallelism] ||= 1
-    Braintrust::Eval.send(:run_internal, **kwargs)
+  def run_test_eval(experiment_id:, experiment_name:, project_id:, project_name:,
+    cases:, task:, scorers:, state:, parallelism: 1, tracer_provider: nil)
+    runner = Braintrust::Eval::Runner.new(
+      experiment_id: experiment_id,
+      experiment_name: experiment_name,
+      project_id: project_id,
+      project_name: project_name,
+      task: task,
+      scorers: scorers,
+      state: state,
+      tracer_provider: tracer_provider
+    )
+    runner.run(cases, parallelism: parallelism)
   end
 
   # Generate unique name for parallel test runs


### PR DESCRIPTION
# Summary

The `Eval` class has a number of static, functional methods that execute test cases. The downside of this design is it requires passing a lot of arguments through to sub-methods which makes method signatures more complicated and isn't as idiomatic.

This pull request migrates much of the test case execution logic into an `Eval::Runner` class which encapsulates much of the execution behavior. This class is instantiated when `Eval.run` is called and keeps the input in instance variables, thereby limiting the number of arguments that need to be passed from function to function.

## Key design decisions

- Simplify logic: make each function do less and limit passthroughs.
- Preserve existing `Eval.run` API (no breaking changes)
- Limit the number of intermediate objects made in the process of execution, to limit GC pressure that could harm performance. (Making one `Runner` object per `Eval` seems like a good balance that scales 1-1.)

## Code changes

- Migrated many functions in `eval.rb` to `eval/runner.rb`
- Added unit tests for `Eval::Runner` to buff up the coverage a bit. (This is the bulk of the lines added.)
- Some minor tweaks to testing utilities to support the change.