### PR TITLE
Use 'dev' user in the Docker dev environment

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
     build: .
     volumes:
       - .:/app
-      - dev-mise-data:/root/.local/share/mise
+      - dev-mise-data:/home/dev/.local/share/mise
       - dev-bundle-cache:/usr/local/bundle
     working_dir: /app
     environment:

--- a/mise.toml
+++ b/mise.toml
@@ -104,8 +104,10 @@ fi
 
 [hooks]
 postinstall = """
-echo "Installing gem dependencies..."
-bundle install
-echo "Setting up git pre-commit hook..."
-mise generate git-pre-commit --write --task=precommit
+if bundle --version > /dev/null 2>&1; then
+  echo "Installing gem dependencies..."
+  bundle install
+  echo "Setting up git pre-commit hook..."
+  mise generate git-pre-commit --write --task=precommit
+fi
 """


### PR DESCRIPTION
This adds a `dev` user to the dev Docker container to (1) make it a bit safer, and (2) prevent file permission errors caused by generating files with tools (such as rake, Claude, etc.)