### PR TITLE
Use .env in Docker dev container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ changelog.md
 
 # Appraisal: commit gemfiles but ignore lock files
 gemfiles/*.gemfile.lock
+
+# Ignore local Docker files (for dev env customizations)
+docker-compose.override.yml
+Dockerfile.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,14 @@ services:
     build: .
     volumes:
       - .:/app
-      - dev-mise-data:/home/dev/.local/share/mise
+      - dev-home:/home/dev/
       - dev-bundle-cache:/usr/local/bundle
     working_dir: /app
+    env_file: .env
     environment:
       - BUNDLE_PATH=/usr/local/bundle
       - MISE_TRUSTED_CONFIG_PATHS=/app
 
 volumes:
-  dev-mise-data:
+  dev-home:
   dev-bundle-cache:


### PR DESCRIPTION
Some quality-of-life improvements for Docker dev:

1. Passthrough the `.env` file (for running examples and such)
2. Allow devs to add `docker-compose.override.yml` and `Dockerfile.local` to further customize a local dev env, if necessary.