### PR TITLE
Use test-api-key to prevent login thread leaks

### DIFF
--- a/test/braintrust/trace/span_filter_test.rb
+++ b/test/braintrust/trace/span_filter_test.rb
@@ -11,9 +11,8 @@ class SpanFilterTest < Minitest::Test
     tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
 
     Braintrust.init(
-      api_key: "test-key",
+      api_key: "test-api-key",
       set_global: false,
-      blocking_login: false,
       enable_tracing: true,
       tracer_provider: tracer_provider,
       exporter: exporter,
@@ -214,9 +213,8 @@ class SpanFilterTest < Minitest::Test
     tracer_provider = OpenTelemetry::SDK::Trace::TracerProvider.new
 
     Braintrust.init(
-      api_key: "test-key",
+      api_key: "test-api-key",
       set_global: false,
-      blocking_login: false,
       enable_tracing: true,
       tracer_provider: tracer_provider,
       exporter: exporter,

--- a/test/braintrust/without_openai_test.rb
+++ b/test/braintrust/without_openai_test.rb
@@ -16,15 +16,15 @@ class WithoutOpenAITest < Minitest::Test
     skip "Test only runs in without-openai appraisal" if openai_available?
 
     # Test that we can initialize Braintrust without tracing (no OpenAI needed)
+    # Note: "test-api-key" triggers fake auth to avoid HTTP requests
     state = Braintrust.init(
-      api_key: "test-key",
+      api_key: "test-api-key",
       set_global: false,
-      blocking_login: false,
       enable_tracing: false
     )
 
     assert_instance_of Braintrust::State, state
-    assert_equal "test-key", state.api_key
+    assert_equal "test-api-key", state.api_key
   end
 
   def test_openai_require_fails_without_gem

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -64,6 +64,29 @@ end
 
 # Test helpers for OpenTelemetry tracing
 module TracingTestHelper
+  # =============================================================================
+  # IMPORTANT: Magic Test API Key
+  # =============================================================================
+  #
+  # When calling Braintrust.init in tests, use api_key: "test-api-key" to trigger
+  # fake authentication that avoids HTTP requests. This magic key is handled in
+  # lib/braintrust/api/internal/auth.rb and returns fake org info immediately.
+  #
+  # Without this magic key, Braintrust.init spawns a background login thread that
+  # can cause WebMock errors after tests complete (orphan thread race condition).
+  #
+  # Example:
+  #   Braintrust.init(api_key: "test-api-key", set_global: false, enable_tracing: true)
+  #
+  # TODO: Future work - move this magic key handling out of production code and into
+  # test helpers instead. Options include:
+  #   1. A test-only initializer that provides org_id directly (skips login entirely)
+  #   2. Dependency injection for the Auth module in tests
+  #   3. Environment-based test mode detection
+  #
+  # See: lib/braintrust/api/internal/auth.rb for the magic key implementation
+  # =============================================================================
+
   # Wrapper for OpenTelemetry test setup
   class OtelTestRig
     attr_reader :tracer_provider, :exporter, :state


### PR DESCRIPTION
## Problem

Many of my new tests were failing locally with WebMock errors.

```                                                                                                                                                                                                                                 
The issue is related to test duration, but it's more specifically about orphan background threads and stub lifecycle:                                                                                                                                        
                                                                                                                                                                                                                                                              
The sequence:                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                              
1. Test A creates State with api_key: "test-key" (no org_id) → spawns background login thread                                                                                                                                                                
2. Login fails (stub returns 500, or cassette doesn't have login stub) → thread enters exponential backoff retry                                                                                                                                             
3. Test A completes → WebMock.reset! clears stubs (or VCR cassette is ejected)                                                                                                                                                                               
4. Test B starts → registers new stub with different Authorization header (e.g., Bearer <BRAINTRUST_API_KEY>)                                                                                                                                                
5. Orphan thread wakes up, tries login with Authorization: Bearer test-key                                                                                                                                                                                   
6. Stub doesn't match → WebMock::NetConnectNotAllowedError                                                                                                                                                                                                   
                                                                                                                                                                                                                                                              
Why some CI jobs are more affected:                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                              
- More tests = more opportunities for:                                                                                                                                                                                                                       
  - Threads to be spawned                                                                                                                                                                                                                                    
  - Threads to be in backoff when stubs change                                                                                                                                                                                                               
  - New tests to register incompatible stubs                                                                                                                                                                                                                 
- Longer test duration increases window for race condition      
```

## Solution

```
There's a magic test key in the code:                                                                                                                                                                                                                        
                                                                                                                                                                                                                                                               
# In lib/braintrust/api/internal/auth.rb                                                                                                                                                                                                                     
if api_key == "test-api-key"                                                                                                                                                                                                                                 
  Log.debug("Login: using test API key, returning fake auth")                                                                                                                                                                                                
  return AuthResult.new(org_id: "test-org-id", ...)                                                                                                                                                                                                          
end                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                              
So api_key: "test-api-key" skips HTTP entirely and returns fake auth.
```

This also happens to short-circuit the login thread. Since this is the current idiomatic approach, apply it for now. In the future, we should eliminate this "magic" behavior and keep test behavior isolated to the test suite.