### PR TITLE
Automatically initialize and instrument with `braintrust exec`

### DIFF
--- a/examples/setup/README.md
+++ b/examples/setup/README.md
@@ -1,0 +1,26 @@
+# Setup Examples
+
+These examples demonstrate different ways to automatically setup the Braintrust SDK.
+
+## Local Development
+
+When running examples from the repo (gem not installed), use these commands:
+
+```bash
+# For init.rb and require.rb examples:
+OPENAI_API_KEY=your-key ANTHROPIC_API_KEY=your-key \
+  bundle exec appraisal contrib ruby examples/setup/init.rb
+
+# For exec.rb examples (reference exe/braintrust directly):
+OPENAI_API_KEY=your-key ANTHROPIC_API_KEY=your-key \
+  bundle exec appraisal contrib exe/braintrust exec -- \
+  ruby examples/setup/exec.rb
+```
+
+## Examples
+
+| File         | Approach                         | Code Changes Required |
+| ------------ | -------------------------------- | --------------------- |
+| `init.rb`    | `Braintrust.init`                | Add init call         |
+| `require.rb` | `require "braintrust/setup"`     | Add require           |
+| `exec.rb`    | `braintrust exec -- ruby app.rb` | None                  |

--- a/examples/setup/exec.rb
+++ b/examples/setup/exec.rb
@@ -1,0 +1,132 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example: Automatic Braintrust SDK setup via braintrust exec
+#
+# This example demonstrates the zero-code-changes approach to auto-instrumentation.
+# Instead of modifying your application code, you simply run it with `braintrust exec`.
+#
+# The CLI:
+#   - Injects auto-setup via RUBYOPT
+#   - Automatically patches LLM libraries as they are loaded
+#   - Initializes Braintrust tracing
+#
+# This is ideal for:
+#   - Existing applications you don't want to modify
+#   - Quick testing and debugging
+#   - Production deployments via process supervisors
+#
+# Supported libraries (instrumented automatically):
+#   - openai (OpenAI's official Ruby gem)
+#   - ruby-openai (alexrudall's ruby-openai gem) *
+#   - anthropic (Anthropic's official Ruby gem)
+#   - ruby_llm (RubyLLM unified interface)
+#
+# * Note: openai and ruby-openai share the same require path ("openai"), so only one
+#   can be loaded at a time. This demo uses the official openai gem.
+#
+# Usage:
+#   OPENAI_API_KEY=your-key ANTHROPIC_API_KEY=your-key \
+#     bundle exec appraisal contrib braintrust exec -- \
+#     ruby examples/setup/exec.rb
+#
+# With filtering:
+#   braintrust exec --only openai,anthropic -- ruby examples/setup/exec.rb
+#   braintrust exec --except ruby_llm -- ruby examples/setup/exec.rb
+
+# Notice: NO braintrust require needed! The CLI handles everything.
+
+require "openai"
+require "anthropic"
+require "ruby_llm"
+require "opentelemetry-sdk"
+
+# Check for required API keys
+missing_keys = []
+missing_keys << "OPENAI_API_KEY" unless ENV["OPENAI_API_KEY"]
+missing_keys << "ANTHROPIC_API_KEY" unless ENV["ANTHROPIC_API_KEY"]
+
+unless missing_keys.empty?
+  puts "Error: Missing required environment variables: #{missing_keys.join(", ")}"
+  puts ""
+  puts "Get your API keys from:"
+  puts "  OpenAI: https://platform.openai.com/api-keys"
+  puts "  Anthropic: https://console.anthropic.com/"
+  exit 1
+end
+
+puts "auto-setup via braintrust exec Demo"
+puts "=" * 50
+puts ""
+puts "This script has NO braintrust imports!"
+puts "The CLI injected auto-setup via RUBYOPT."
+puts ""
+
+# Brief pause to allow async Braintrust login to complete
+# (Not necessary in production, just for this short lived example)
+sleep 0.5
+
+# Configure RubyLLM
+RubyLLM.configure do |config|
+  config.openai_api_key = ENV["OPENAI_API_KEY"]
+end
+
+# Create clients for each library
+openai_client = OpenAI::Client.new(api_key: ENV["OPENAI_API_KEY"])
+anthropic_client = Anthropic::Client.new(api_key: ENV["ANTHROPIC_API_KEY"])
+
+# Create a tracer and root span to capture all operations
+tracer = OpenTelemetry.tracer_provider.tracer("setup-exec-demo")
+root_span = nil
+
+puts "Making API calls with each library..."
+puts "-" * 50
+
+tracer.in_span("examples/setup/exec.rb") do |span|
+  root_span = span
+
+  # 1. OpenAI (official gem)
+  puts ""
+  puts "[1/3] OpenAI (official gem)..."
+  openai_response = openai_client.chat.completions.create(
+    model: "gpt-4o-mini",
+    max_tokens: 50,
+    messages: [
+      {role: "user", content: "Say 'Hello from OpenAI!' in exactly 5 words."}
+    ]
+  )
+  puts "      Response: #{openai_response.choices[0].message.content}"
+
+  # 2. Anthropic
+  puts ""
+  puts "[2/3] Anthropic..."
+  anthropic_response = anthropic_client.messages.create(
+    model: "claude-3-haiku-20240307",
+    max_tokens: 50,
+    messages: [
+      {role: "user", content: "Say 'Hello from Anthropic!' in exactly 5 words."}
+    ]
+  )
+  puts "      Response: #{anthropic_response.content[0].text}"
+
+  # 3. RubyLLM (using OpenAI provider)
+  puts ""
+  puts "[3/3] RubyLLM (via OpenAI)..."
+  chat = RubyLLM.chat(model: "gpt-4o-mini")
+  ruby_llm_response = chat.ask("Say 'Hello from RubyLLM!' in exactly 5 words.")
+  puts "      Response: #{ruby_llm_response.content}"
+end
+
+puts ""
+puts "-" * 50
+puts ""
+puts "All API calls complete!"
+puts ""
+puts "View trace in Braintrust:"
+puts "  #{Braintrust::Trace.permalink(root_span)}"
+puts ""
+
+# Shutdown to flush spans (not necessary in production, just for this short lived example)
+OpenTelemetry.tracer_provider.shutdown
+
+puts "Trace sent to Braintrust!"

--- a/examples/setup/exec_minimal.rb
+++ b/examples/setup/exec_minimal.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# No braintrust require needed - the CLI handles everything!
+require "openai"
+require "anthropic"
+require "ruby_llm"
+require "opentelemetry-sdk"
+
+# Brief pause to allow async Braintrust login to complete
+# (Not necessary in production, just for this short lived example)
+sleep 0.5
+
+RubyLLM.configure { |c| c.openai_api_key = ENV["OPENAI_API_KEY"] }
+
+openai_client = OpenAI::Client.new(api_key: ENV["OPENAI_API_KEY"])
+anthropic_client = Anthropic::Client.new(api_key: ENV["ANTHROPIC_API_KEY"])
+tracer = OpenTelemetry.tracer_provider.tracer("setup-exec-demo")
+
+tracer.in_span("examples/setup/exec_minimal.rb") do
+  openai_client.chat.completions.create(
+    model: "gpt-4o-mini",
+    messages: [{role: "user", content: "Hello from OpenAI"}]
+  )
+
+  anthropic_client.messages.create(
+    model: "claude-3-haiku-20240307",
+    max_tokens: 50,
+    messages: [{role: "user", content: "Hello from Anthropic"}]
+  )
+
+  RubyLLM.chat(model: "gpt-4o-mini").ask("Hello from RubyLLM")
+end
+
+# Shutdown to flush spans
+# (Not necessary in production, just for this short lived example)
+OpenTelemetry.tracer_provider.shutdown

--- a/exe/braintrust
+++ b/exe/braintrust
@@ -1,0 +1,143 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Braintrust CLI - Auto-instrument Ruby applications
+#
+# Usage:
+#   braintrust exec -- ruby app.rb
+#   braintrust exec -- bundle exec rails server
+#   braintrust exec --only openai,anthropic -- ruby app.rb
+
+require "optparse"
+
+module Braintrust
+  module CLI
+    class << self
+      def run(args)
+        command = parse_args(args)
+
+        case command
+        when :exec
+          exec_command
+        when :help, nil
+          print_help
+          exit((command == :help) ? 0 : 1)
+        else
+          puts "Unknown command: #{command}"
+          print_help
+          exit 1
+        end
+      end
+
+      private
+
+      def parse_args(args)
+        @options = {}
+        @remaining_args = []
+
+        # Find -- separator
+        separator_index = args.index("--")
+        if separator_index
+          to_parse = args[0...separator_index]
+          @remaining_args = args[(separator_index + 1)..]
+        else
+          to_parse = args.dup
+        end
+
+        parser = OptionParser.new do |opts|
+          opts.banner = "Usage: braintrust <command> [options] -- COMMAND"
+
+          opts.on("--only INTEGRATIONS", "Only instrument these (comma-separated)") do |v|
+            @options[:only] = v
+          end
+
+          opts.on("--except INTEGRATIONS", "Skip these integrations (comma-separated)") do |v|
+            @options[:except] = v
+          end
+
+          opts.on("-h", "--help", "Show this help") do
+            return :help
+          end
+
+          opts.on("-v", "--version", "Show version") do
+            require_relative "../lib/braintrust/version"
+            puts "braintrust #{Braintrust::VERSION}"
+            exit 0
+          end
+        end
+
+        parser.parse!(to_parse)
+
+        return nil if to_parse.empty?
+        to_parse.first.to_sym
+      end
+
+      def exec_command
+        if @remaining_args.empty?
+          puts "Error: No command specified after --"
+          puts "Usage: braintrust exec [options] -- COMMAND"
+          exit 1
+        end
+
+        # Set environment variables for filtering
+        ENV["BRAINTRUST_INSTRUMENT_ONLY"] = @options[:only] if @options[:only]
+        ENV["BRAINTRUST_INSTRUMENT_EXCEPT"] = @options[:except] if @options[:except]
+
+        # Inject auto-instrument via RUBYOPT
+        set_rubyopt!
+
+        # Execute the command with error handling
+        exec_with_error_handling(@remaining_args)
+      end
+
+      def rubyopts
+        ["-rbraintrust/setup"]
+      end
+
+      def set_rubyopt!
+        existing = ENV["RUBYOPT"]
+        ENV["RUBYOPT"] = existing ? "#{existing} #{rubyopts.join(" ")}" : rubyopts.join(" ")
+      end
+
+      def exec_with_error_handling(args)
+        Kernel.exec(*args)
+      rescue Errno::ENOENT => e
+        Kernel.warn "braintrust exec failed: #{e.class.name} #{e.message}"
+        Kernel.exit 127
+      rescue Errno::EACCES, Errno::ENOEXEC => e
+        Kernel.warn "braintrust exec failed: #{e.class.name} #{e.message}"
+        Kernel.exit 126
+      end
+
+      def print_help
+        puts <<~HELP
+          Braintrust CLI - Auto-instrument Ruby applications
+
+          Usage:
+            braintrust exec [options] -- COMMAND
+
+          Commands:
+            exec    Run a command with auto-instrumentation enabled
+
+          Options:
+            --only INTEGRATIONS     Only instrument these (comma-separated)
+            --except INTEGRATIONS   Skip these integrations (comma-separated)
+            -h, --help              Show this help
+            -v, --version           Show version
+
+          Examples:
+            braintrust exec -- ruby app.rb
+            braintrust exec -- rails server
+            braintrust exec --only openai -- ruby app.rb
+
+          Environment Variables:
+            BRAINTRUST_API_KEY              API key for Braintrust
+            BRAINTRUST_INSTRUMENT_ONLY      Comma-separated whitelist
+            BRAINTRUST_INSTRUMENT_EXCEPT    Comma-separated blacklist
+        HELP
+      end
+    end
+  end
+end
+
+Braintrust::CLI.run(ARGV)


### PR DESCRIPTION
## Purpose

This PR introduces a new `braintrust exec` CLI command that enables auto-instrumentation of Ruby applications **without any code changes**. This is the third and most frictionless approach to enabling Braintrust tracing, complementing the existing `Braintrust.init` and `require "braintrust/setup"` methods.

The key benefit is that users can instrument existing applications simply by prefixing their run command with `braintrust exec --`.

## Usage Examples

***Before you begin**: the `braintrust` gem must be installed on your system to make the CLI available in your PATH.*

### Basic Usage
```bash
# Run a Ruby script with auto-instrumentation
braintrust exec -- ruby app.rb

# Run a Rails server with auto-instrumentation
braintrust exec -- rails server

# Run with bundler
braintrust exec -- bundle exec rails server
```

### Filtering Integrations
```bash
# Only instrument OpenAI and Anthropic
braintrust exec --only openai,anthropic -- ruby app.rb

# Instrument everything except RubyLLM
braintrust exec --except ruby_llm -- ruby app.rb
```

### Help and Version
```bash
braintrust --help
braintrust --version
```

## Comparison: Three Approaches to Auto-Instrumentation

| Approach                     | Code Changes             | Best For                                             |
| ---------------------------- | ------------------------ | ---------------------------------------------------- |
| `Braintrust.init`            | Add init call            | Customized control                       |
| `require "braintrust/setup"` | Add require (or Gemfile) | Rails or Bundler-enabled Ruby applications                      |
| `braintrust exec -- cmd`     | **None**                 | When you can't easily change the Ruby application source code or dependencies |

---

**NOTE:** Using `braintrust exec` requires the `braintrust` gem be installed onto your system (if you want zero-code changes to an application). This means ***there are inherent limitations for compatibility***, as the system-installed version of the `braintrust` gem could potentially have conflicts with your Ruby application dependencies.

Using this CLI approach is for when you can't easily add the `braintrust` gem directly to your application. We recommend using `require 'braintrust/setup'` in combination with Bundler in your Ruby application whenever possible to maximize compatibility.

---

## Environment Variables

| Variable                       | Description                                   |
| ------------------------------ | --------------------------------------------- |
| `BRAINTRUST_API_KEY`           | Required for tracing                          |
| `BRAINTRUST_INSTRUMENT_ONLY`   | Comma-separated whitelist (set by `--only`)   |
| `BRAINTRUST_INSTRUMENT_EXCEPT` | Comma-separated blacklist (set by `--except`) |

## Architectural Overview

### How It Works

The CLI uses Ruby's `RUBYOPT` environment variable to inject `-rbraintrust/setup` before the target application runs:

```
braintrust exec -- ruby app.rb
        │
        ├─► Sets RUBYOPT="-rbraintrust/setup"
        │
        └─► Kernel.exec("ruby", "app.rb")
                │
                └─► Ruby automatically loads braintrust/setup
                        │
                        ├─► Calls Braintrust.init
                        └─► Calls Contrib::Setup.run! (patches LLM libraries)
```

### CLI Implementation Details

The CLI module in `exe/braintrust`:
- Parses `--only` and `--except` flags for filtering integrations
- Handles the `--` separator to distinguish CLI args from command args
- Sets `BRAINTRUST_INSTRUMENT_ONLY`/`BRAINTRUST_INSTRUMENT_EXCEPT` env vars for filtering
- Provides graceful error handling for `ENOENT` (command not found), `EACCES`, and `ENOEXEC`
- Returns appropriate exit codes (127 for not found, 126 for permission errors)

### Files Added

| File                             | Description                                                           |
| -------------------------------- | --------------------------------------------------------------------- |
| `exe/braintrust`                 | CLI executable with argument parsing, option handling, and exec logic |
| `examples/setup/exec.rb`         | Full example demonstrating all supported LLM libraries                |
| `examples/setup/exec_minimal.rb` | Minimal working example                                               |
| `examples/setup/README.md`       | Documentation comparing all three setup approaches                    |
