### PR TITLE
Force flush traces at_exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Braintrust.init(
 | `BRAINTRUST_AUTO_INSTRUMENT`      | Set to `false` to disable auto-instrumentation                            |
 | `BRAINTRUST_DEBUG`                | Set to `true` to enable debug logging                                     |
 | `BRAINTRUST_DEFAULT_PROJECT`      | Default project for spans                                                 |
+| `BRAINTRUST_FLUSH_ON_EXIT`        | Set to `false` to disable automatic span flushing on program exit         |
 | `BRAINTRUST_INSTRUMENT_EXCEPT`    | Comma-separated list of integrations to skip                              |
 | `BRAINTRUST_INSTRUMENT_ONLY`      | Comma-separated list of integrations to enable (e.g., `openai,anthropic`) |
 | `BRAINTRUST_ORG_NAME`             | Organization name                                                         |

--- a/lib/braintrust/internal/env.rb
+++ b/lib/braintrust/internal/env.rb
@@ -7,9 +7,15 @@ module Braintrust
       ENV_AUTO_INSTRUMENT = "BRAINTRUST_AUTO_INSTRUMENT"
       ENV_INSTRUMENT_EXCEPT = "BRAINTRUST_INSTRUMENT_EXCEPT"
       ENV_INSTRUMENT_ONLY = "BRAINTRUST_INSTRUMENT_ONLY"
+      ENV_FLUSH_ON_EXIT = "BRAINTRUST_FLUSH_ON_EXIT"
 
       def self.auto_instrument
         ENV[ENV_AUTO_INSTRUMENT] != "false"
+      end
+
+      # Whether to automatically flush spans on program exit. Default: true
+      def self.flush_on_exit
+        ENV[ENV_FLUSH_ON_EXIT] != "false"
       end
 
       def self.instrument_except

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -90,6 +90,8 @@ class Minitest::Test
   # This ensures cleanup happens even if individual tests don't have teardown methods
   def after_teardown
     Braintrust::State.instance_variable_set(:@global_state, nil)
+    OpenTelemetry.tracer_provider = OpenTelemetry::Internal::ProxyTracerProvider.new
+    Braintrust::Trace.exit_hook_registered = false
     super
   end
 end


### PR DESCRIPTION
Adds automatic span flushing on program exit to prevent data loss from buffered traces.

## Problem

The OpenTelemetry `BatchSpanProcessor` buffers spans before export. If a Ruby process exits before the buffer flushes, those spans are lost silently. This is especially common in short-lived scripts or CLI tools.

## Solution

Register an `at_exit` hook that calls `force_flush` on the tracer provider, ensuring all buffered spans are exported before the process terminates.

## Configuration

| Variable | Default | Description |
|----------|---------|-------------|
| `BRAINTRUST_FLUSH_ON_EXIT` | `true` | Set to `false` to disable automatic flushing |

Disabling may be useful in long-running processes where graceful shutdown is handled separately, or in test environments where the overhead is undesirable.
