### PR TITLE
Fix Anthropic system prompt not captured in traces

### DIFF
--- a/lib/braintrust/contrib/anthropic/instrumentation/beta_messages.rb
+++ b/lib/braintrust/contrib/anthropic/instrumentation/beta_messages.rb
@@ -169,8 +169,8 @@ module Braintrust
               input_messages = []
 
               begin
-                if params[:system]
-                  system_content = params[:system]
+                if params[:system_]
+                  system_content = params[:system_]
                   if system_content.is_a?(Array)
                     system_text = system_content.map { |blk|
                       blk.is_a?(Hash) ? blk[:text] : blk

--- a/lib/braintrust/contrib/anthropic/instrumentation/messages.rb
+++ b/lib/braintrust/contrib/anthropic/instrumentation/messages.rb
@@ -98,8 +98,8 @@ module Braintrust
             def set_input(span, params)
               input_messages = []
 
-              if params[:system]
-                system_content = params[:system]
+              if params[:system_]
+                system_content = params[:system_]
                 if system_content.is_a?(Array)
                   system_text = system_content.map { |blk|
                     blk.is_a?(Hash) ? blk[:text] : blk

--- a/test/braintrust/contrib/anthropic/instrumentation/messages_test.rb
+++ b/test/braintrust/contrib/anthropic/instrumentation/messages_test.rb
@@ -130,7 +130,7 @@ class Braintrust::Contrib::Anthropic::Instrumentation::MessagesTest < Minitest::
       message = client.messages.create(
         model: "claude-sonnet-4-20250514",
         max_tokens: 20,
-        system: "You are a helpful assistant that always responds briefly.",
+        system_: "You are a helpful assistant that always responds briefly.",
         messages: [
           {role: "user", content: "Say hello"}
         ]


### PR DESCRIPTION
## Issue
The [Anthropic Ruby SDK](https://platform.claude.com/docs/en/api/ruby/messages/create) uses `system_:` (with trailing underscore) as the keyword argument name because `system` is a reserved method in Ruby (Kernel#system). 

Our instrumentation implementation was checking for `params[:system]` which never matched, causing system prompts to be silently dropped from Braintrust traces:

<img width="1285" height="582" alt="RubyAnthropicSystemBug" src="https://github.com/user-attachments/assets/8b1b5418-4ffc-4d2d-90b1-d9edf59115dd" />


## Changes
Update both messages.rb and beta_messages.rb to use `params[:system_]` to match the official Anthropic Ruby SDK semantics. 

Tested fix and we are now properly capturing `system_` as the system prompt in our logs:
<img width="1283" height="528" alt="RubyAnthropicSystemFix" src="https://github.com/user-attachments/assets/c020514b-ffa7-448a-b389-1998e898f015" />

