### PR TITLE
Fix experiment-dataset linking when running evals with a dataset

### DIFF
--- a/lib/braintrust/api/internal/experiments.rb
+++ b/lib/braintrust/api/internal/experiments.rb
@@ -22,7 +22,8 @@ module Braintrust
         # @param tags [Array<String>, nil] Optional tags
         # @param metadata [Hash, nil] Optional metadata
         # @return [Hash] Experiment data with "id", "name", "project_id", etc.
-        def create(name:, project_id:, ensure_new: true, tags: nil, metadata: nil)
+        def create(name:, project_id:, ensure_new: true, tags: nil, metadata: nil,
+          dataset_id: nil, dataset_version: nil)
           uri = URI("#{@state.api_url}/v1/experiment")
 
           payload = {
@@ -32,6 +33,8 @@ module Braintrust
           }
           payload[:tags] = tags if tags
           payload[:metadata] = metadata if metadata
+          payload[:dataset_id] = dataset_id if dataset_id
+          payload[:dataset_version] = dataset_version if dataset_version
 
           request = Net::HTTP::Post.new(uri)
           request["Content-Type"] = "application/json"


### PR DESCRIPTION
## The issue

When running evals with a dataset via `Braintrust::Eval.run`, the resulting experiment is not linked to the dataset in the Braintrust UI. The UI shows "Rows not attached to a dataset" because `dataset_id` and `dataset_version` are never included in the experiment creation request:

<img width="221" height="93" alt="Screenshot 2026-02-14 at 4 40 37 PM" src="https://github.com/user-attachments/assets/9c080b6a-fb70-4aa0-9119-c1b3c1a58ebd" />

The issue is that `Eval.resolve_dataset` resolved a dataset to an array of cases but discarded the `Dataset` object, so `dataset_obj.id` was never captured. `Experiments#create` did not accept or send `dataset_id` and `dataset_version` in the `POST /v1/experiment` payload, even though the API supports both fields.

Additionally, `Dataset#version` returns nil when the dataset is not explicitly pinned to a version. The Python SDK handles this by computing the version as `max(_xact_id)` across all records in the fetched dataset, but the Ruby SDK does not.

## Fix

`Eval.resolve_dataset` now returns a hash with `:cases`, `:dataset_id`, and `:dataset_version` instead of a plain array. When no pinned version is available, it computes `dataset_version` from `max(_xact_id)` across fetched records (matching the Python SDK behavior).

`Eval.run` retrieves `dataset_id` and `dataset_version` from the resolved dataset and forwards them to the experiment-creation process. `Experiments#create` accepts optional `dataset_id` and `dataset_version` keyword arguments and includes them in the API payload when present.

After the fix got applied:

<img width="252" height="107" alt="Screenshot 2026-02-14 at 4 44 46 PM" src="https://github.com/user-attachments/assets/96cdc942-98f0-4d59-a847-ace096b36c9e" />

## Tests

Added assertion to the existing dataset eval test verifying that `dataset_id` and `dataset_version` are sent in the `POST /v1/experiment` request body.

Added `test_eval_run_without_dataset_does_not_send_dataset_fields` to verify that `dataset_id` and `dataset_version` are `nil` when no dataset is provided.