### PR TITLE
Remove secrets requirements for tests

### DIFF
--- a/test/braintrust/api/datasets_test.rb
+++ b/test/braintrust/api/datasets_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 
 class Braintrust::API::DatasetsTest < Minitest::Test
   def setup
-    flunk "BRAINTRUST_API_KEY not set" unless ENV["BRAINTRUST_API_KEY"]
     @project_name = "ruby-sdk-test"
   end
 

--- a/test/braintrust/api/functions_test.rb
+++ b/test/braintrust/api/functions_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 
 class Braintrust::API::FunctionsTest < Minitest::Test
   def setup
-    flunk "BRAINTRUST_API_KEY not set" unless ENV["BRAINTRUST_API_KEY"]
     @project_name = "ruby-sdk-test"
   end
 

--- a/test/braintrust/api_test.rb
+++ b/test/braintrust/api_test.rb
@@ -4,7 +4,6 @@ require "test_helper"
 
 class Braintrust::APITest < Minitest::Test
   def setup
-    flunk "BRAINTRUST_API_KEY not set" unless ENV["BRAINTRUST_API_KEY"]
   end
 
   def test_api_new_with_explicit_state

--- a/test/braintrust/eval/functions_test.rb
+++ b/test/braintrust/eval/functions_test.rb
@@ -6,7 +6,6 @@ require "braintrust/eval/functions"
 
 class Braintrust::Eval::FunctionsTest < Minitest::Test
   def setup
-    flunk "BRAINTRUST_API_KEY not set" unless ENV["BRAINTRUST_API_KEY"]
     @project_name = "ruby-sdk-test"
   end
 

--- a/test/braintrust/prompt_test.rb
+++ b/test/braintrust/prompt_test.rb
@@ -271,7 +271,6 @@ end
 
 class Braintrust::PromptLoadTest < Minitest::Test
   def setup
-    flunk "BRAINTRUST_API_KEY not set" unless ENV["BRAINTRUST_API_KEY"]
     @project_name = "ruby-sdk-test"
   end
 


### PR DESCRIPTION
When GHA runs against contributions made from forks, it cannot use secrets. Because some tests require the presence of secrets, this means CI blocks, preventing merges.

This pull request removes these requirements such that CI can run without any secrets.