### PR TITLE
Follow 303 redirects when the API returns them

### DIFF
--- a/lib/braintrust/api/functions.rb
+++ b/lib/braintrust/api/functions.rb
@@ -4,6 +4,7 @@ require "net/http"
 require "json"
 require "uri"
 require_relative "../logger"
+require_relative "../internal/http"
 
 module Braintrust
   class API
@@ -242,9 +243,7 @@ module Braintrust
         start_time = Time.now
         Log.debug("[API] #{method.upcase} #{uri}")
 
-        http = Net::HTTP.new(uri.host, uri.port)
-        http.use_ssl = (uri.scheme == "https")
-        response = http.request(request)
+        response = Braintrust::Internal::Http.with_redirects(uri, request)
 
         duration_ms = ((Time.now - start_time) * 1000).round(2)
         Log.debug("[API] #{method.upcase} #{uri} -> #{response.code} (#{duration_ms}ms, #{response.body.bytesize} bytes)")

--- a/lib/braintrust/api/internal/auth.rb
+++ b/lib/braintrust/api/internal/auth.rb
@@ -4,6 +4,7 @@ require "net/http"
 require "json"
 require "uri"
 require_relative "../../logger"
+require_relative "../../internal/http"
 
 module Braintrust
   class API
@@ -44,12 +45,7 @@ module Braintrust
           request = Net::HTTP::Post.new(uri)
           request["Authorization"] = "Bearer #{api_key}"
 
-          http = Net::HTTP.new(uri.hostname, uri.port)
-          http.use_ssl = true if uri.scheme == "https"
-
-          response = http.start do |http_session|
-            http_session.request(request)
-          end
+          response = Braintrust::Internal::Http.with_redirects(uri, request)
 
           Log.debug("Login: received response [#{response.code}]")
 

--- a/lib/braintrust/api/internal/experiments.rb
+++ b/lib/braintrust/api/internal/experiments.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "json"
 require "uri"
+require_relative "../../internal/http"
 
 module Braintrust
   class API
@@ -41,9 +42,7 @@ module Braintrust
           request["Authorization"] = "Bearer #{@state.api_key}"
           request.body = JSON.dump(payload)
 
-          http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = (uri.scheme == "https")
-          response = http.request(request)
+          response = Braintrust::Internal::Http.with_redirects(uri, request)
 
           unless response.is_a?(Net::HTTPSuccess)
             raise Error, "HTTP #{response.code} for POST #{uri}: #{response.body}"

--- a/lib/braintrust/api/internal/projects.rb
+++ b/lib/braintrust/api/internal/projects.rb
@@ -3,6 +3,7 @@
 require "net/http"
 require "json"
 require "uri"
+require_relative "../../internal/http"
 
 module Braintrust
   class API
@@ -26,9 +27,7 @@ module Braintrust
           request["Authorization"] = "Bearer #{@state.api_key}"
           request.body = JSON.dump({name: name})
 
-          http = Net::HTTP.new(uri.host, uri.port)
-          http.use_ssl = (uri.scheme == "https")
-          response = http.request(request)
+          response = Braintrust::Internal::Http.with_redirects(uri, request)
 
           unless response.is_a?(Net::HTTPSuccess)
             raise Error, "HTTP #{response.code} for POST #{uri}: #{response.body}"

--- a/lib/braintrust/internal/http.rb
+++ b/lib/braintrust/internal/http.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "net/http"
+require "uri"
+require "zlib"
+require "stringio"
+require_relative "../logger"
+
+module Braintrust
+  module Internal
+    # HTTP utilities for redirect following and response decompression.
+    # Drop-in enhancement for raw Net::HTTP request calls throughout the SDK.
+    module Http
+      DEFAULT_MAX_REDIRECTS = 5
+
+      # Execute an HTTP request, following redirects as needed.
+      #
+      # @param uri [URI] The request URI
+      # @param request [Net::HTTPRequest] The prepared request object
+      # @param max_redirects [Integer] Maximum number of redirects to follow
+      # @return [Net::HTTPResponse] The final response
+      # @raise [Braintrust::Error] On too many redirects or missing Location header
+      def self.with_redirects(uri, request, max_redirects: DEFAULT_MAX_REDIRECTS)
+        response = perform_request(uri, request)
+
+        redirects = 0
+        original_request = request
+
+        while response.is_a?(Net::HTTPRedirection)
+          redirects += 1
+          if redirects > max_redirects
+            raise Error, "Too many redirects (max #{max_redirects})"
+          end
+
+          location = response["location"]
+          unless location
+            raise Error, "Redirect response #{response.code} without Location header"
+          end
+
+          redirect_uri = URI(location)
+          redirect_uri = uri + redirect_uri unless redirect_uri.host
+
+          Log.debug("[HTTP] Following #{response.code} redirect to #{redirect_uri}")
+
+          request = build_redirect_request(response, redirect_uri, original_request, uri)
+          uri = redirect_uri
+          response = perform_request(uri, request)
+        end
+
+        response
+      end
+
+      # Decompress an HTTP response body in place based on Content-Encoding.
+      # No-op if the response has no recognized encoding.
+      #
+      # @param response [Net::HTTPResponse] The response to decompress
+      # @return [void]
+      def self.decompress_response!(response)
+        encoding = response["content-encoding"]&.downcase
+        case encoding
+        when "gzip", "x-gzip"
+          gz = Zlib::GzipReader.new(StringIO.new(response.body))
+          response.body.replace(gz.read)
+          gz.close
+          response.delete("content-encoding")
+        end
+      end
+
+      def self.perform_request(uri, request)
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == "https")
+        http.request(request)
+      end
+      private_class_method :perform_request
+
+      def self.build_redirect_request(response, redirect_uri, original_request, original_uri)
+        if response.code == "307" || response.code == "308"
+          request = original_request.class.new(redirect_uri)
+          request.body = original_request.body
+          request["Content-Type"] = original_request["Content-Type"] if original_request["Content-Type"]
+        else
+          # 301, 302, 303: follow with GET, no body
+          request = Net::HTTP::Get.new(redirect_uri)
+        end
+
+        # Strip Authorization when redirecting to a different host (e.g. S3)
+        if original_uri.host == redirect_uri.host
+          auth = original_request["Authorization"]
+          request["Authorization"] = auth if auth
+        end
+
+        request
+      end
+      private_class_method :build_redirect_request
+    end
+  end
+end

--- a/lib/braintrust/trace/attachment.rb
+++ b/lib/braintrust/trace/attachment.rb
@@ -2,6 +2,7 @@
 
 require "net/http"
 require_relative "../internal/encoding"
+require_relative "../internal/http"
 require "uri"
 
 module Braintrust
@@ -91,7 +92,8 @@ module Braintrust
       #   att = Braintrust::Trace::Attachment.from_url("https://example.com/image.png")
       def self.from_url(url)
         uri = URI.parse(url)
-        response = Net::HTTP.get_response(uri)
+        request = Net::HTTP::Get.new(uri)
+        response = Braintrust::Internal::Http.with_redirects(uri, request)
 
         unless response.is_a?(Net::HTTPSuccess)
           raise StandardError, "Failed to fetch URL: #{response.code} #{response.message}"

--- a/test/braintrust/api/internal/auth_test.rb
+++ b/test/braintrust/api/internal/auth_test.rb
@@ -91,7 +91,7 @@ class Braintrust::API::Internal::AuthTest < Minitest::Test
 
   def test_login_unexpected_response
     stub = stub_request(:post, "https://www.braintrust.dev/api/apikey/login")
-      .to_return(status: 301, body: "", headers: {})
+      .to_return(status: 100, body: "", headers: {})
 
     error = assert_raises(Braintrust::Error) do
       Braintrust::API::Internal::Auth.login(
@@ -101,7 +101,7 @@ class Braintrust::API::Internal::AuthTest < Minitest::Test
     end
 
     assert_match(/unexpected response/i, error.message)
-    assert_match(/301/, error.message)
+    assert_match(/100/, error.message)
   ensure
     remove_request_stub(stub)
   end

--- a/test/braintrust/internal/http_test.rb
+++ b/test/braintrust/internal/http_test.rb
@@ -1,0 +1,199 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "braintrust/internal/http"
+
+class Braintrust::Internal::HttpTest < Minitest::Test
+  # -- with_redirects --
+
+  def test_with_redirects_returns_response_on_success
+    stub = stub_request(:get, "https://api.example.com/v1/dataset")
+      .to_return(status: 200, body: '{"ok":true}')
+
+    uri = URI("https://api.example.com/v1/dataset")
+    request = Net::HTTP::Get.new(uri)
+
+    response = Braintrust::Internal::Http.with_redirects(uri, request)
+
+    assert_equal "200", response.code
+    assert_equal '{"ok":true}', response.body
+  ensure
+    remove_request_stub(stub)
+  end
+
+  def test_with_redirects_follows_303_to_different_host_with_get
+    api_stub = stub_request(:post, "https://api.example.com/btql")
+      .to_return(
+        status: 303,
+        headers: {"Location" => "https://s3.amazonaws.com/bucket/response.jsonl"}
+      )
+
+    # Stub only accepts GET with no Authorization - verifies method conversion and auth stripping
+    s3_stub = stub_request(:get, "https://s3.amazonaws.com/bucket/response.jsonl")
+      .with { |req| req.headers["Authorization"].nil? }
+      .to_return(status: 200, body: '{"id":"1"}')
+
+    uri = URI("https://api.example.com/btql")
+    request = Net::HTTP::Post.new(uri)
+    request["Authorization"] = "Bearer secret-token"
+    request["Content-Type"] = "application/json"
+    request.body = '{"query":"test"}'
+
+    response = Braintrust::Internal::Http.with_redirects(uri, request)
+
+    assert_equal "200", response.code
+    assert_equal '{"id":"1"}', response.body
+    assert_requested(s3_stub, times: 1)
+  ensure
+    remove_request_stub(api_stub)
+    remove_request_stub(s3_stub)
+  end
+
+  def test_with_redirects_preserves_auth_for_same_host
+    redirect_stub = stub_request(:get, "https://api.example.com/old")
+      .to_return(
+        status: 303,
+        headers: {"Location" => "https://api.example.com/new"}
+      )
+
+    # Stub requires Authorization header - verifies auth is preserved for same host
+    target_stub = stub_request(:get, "https://api.example.com/new")
+      .with(headers: {"Authorization" => "Bearer secret-token"})
+      .to_return(status: 200, body: "ok")
+
+    uri = URI("https://api.example.com/old")
+    request = Net::HTTP::Get.new(uri)
+    request["Authorization"] = "Bearer secret-token"
+
+    Braintrust::Internal::Http.with_redirects(uri, request)
+
+    assert_requested(target_stub, times: 1)
+  ensure
+    remove_request_stub(redirect_stub)
+    remove_request_stub(target_stub)
+  end
+
+  def test_with_redirects_307_preserves_method_and_body
+    redirect_stub = stub_request(:post, "https://api.example.com/old")
+      .to_return(
+        status: 307,
+        headers: {"Location" => "https://api.example.com/new"}
+      )
+
+    # Stub requires POST with matching body and content-type - verifies method/body preservation
+    target_stub = stub_request(:post, "https://api.example.com/new")
+      .with(body: '{"data":1}', headers: {"Content-Type" => "application/json"})
+      .to_return(status: 200, body: "ok")
+
+    uri = URI("https://api.example.com/old")
+    request = Net::HTTP::Post.new(uri)
+    request["Content-Type"] = "application/json"
+    request["Authorization"] = "Bearer secret-token"
+    request.body = '{"data":1}'
+
+    Braintrust::Internal::Http.with_redirects(uri, request)
+
+    assert_requested(target_stub, times: 1)
+  ensure
+    remove_request_stub(redirect_stub)
+    remove_request_stub(target_stub)
+  end
+
+  def test_with_redirects_raises_on_too_many_redirects
+    stubs = (0..5).map { |i|
+      stub_request(:get, "https://api.example.com/r#{i}")
+        .to_return(
+          status: 302,
+          headers: {"Location" => "https://api.example.com/r#{i + 1}"}
+        )
+    }
+
+    uri = URI("https://api.example.com/r0")
+    request = Net::HTTP::Get.new(uri)
+
+    error = assert_raises(Braintrust::Error) do
+      Braintrust::Internal::Http.with_redirects(uri, request)
+    end
+
+    assert_match(/too many redirects/i, error.message)
+  ensure
+    stubs.each { |s| remove_request_stub(s) }
+  end
+
+  def test_with_redirects_respects_custom_max_redirects
+    stubs = (0..2).map { |i|
+      stub_request(:get, "https://api.example.com/r#{i}")
+        .to_return(
+          status: 302,
+          headers: {"Location" => "https://api.example.com/r#{i + 1}"}
+        )
+    }
+
+    uri = URI("https://api.example.com/r0")
+    request = Net::HTTP::Get.new(uri)
+
+    error = assert_raises(Braintrust::Error) do
+      Braintrust::Internal::Http.with_redirects(uri, request, max_redirects: 2)
+    end
+
+    assert_match(/too many redirects.*max 2/i, error.message)
+  ensure
+    stubs.each { |s| remove_request_stub(s) }
+  end
+
+  def test_with_redirects_raises_on_missing_location_header
+    stub = stub_request(:get, "https://api.example.com/missing")
+      .to_return(status: 303)
+
+    uri = URI("https://api.example.com/missing")
+    request = Net::HTTP::Get.new(uri)
+
+    error = assert_raises(Braintrust::Error) do
+      Braintrust::Internal::Http.with_redirects(uri, request)
+    end
+
+    assert_match(/without location header/i, error.message)
+  ensure
+    remove_request_stub(stub)
+  end
+
+  # -- decompress_response! --
+
+  def test_decompress_response_handles_gzip
+    original = "hello world"
+    gzipped = gzip_string(original)
+
+    stub = stub_request(:get, "https://s3.example.com/data.jsonl.gz")
+      .to_return(
+        status: 200,
+        body: gzipped,
+        headers: {"Content-Encoding" => "gzip"}
+      )
+
+    uri = URI("https://s3.example.com/data.jsonl.gz")
+    request = Net::HTTP::Get.new(uri)
+    response = Braintrust::Internal::Http.with_redirects(uri, request)
+
+    Braintrust::Internal::Http.decompress_response!(response)
+
+    assert_equal original, response.body
+    assert_nil response["content-encoding"]
+  ensure
+    remove_request_stub(stub)
+  end
+
+  def test_decompress_response_noop_without_encoding
+    stub = stub_request(:get, "https://api.example.com/data")
+      .to_return(status: 200, body: '{"ok":true}')
+
+    uri = URI("https://api.example.com/data")
+    request = Net::HTTP::Get.new(uri)
+    response = Braintrust::Internal::Http.with_redirects(uri, request)
+
+    Braintrust::Internal::Http.decompress_response!(response)
+
+    assert_equal '{"ok":true}', response.body
+  ensure
+    remove_request_stub(stub)
+  end
+end

--- a/test/support/compression_helper.rb
+++ b/test/support/compression_helper.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require "zlib"
+require "stringio"
+
+module Test
+  module Support
+    module CompressionHelper
+      def gzip_string(str)
+        io = StringIO.new
+        io.set_encoding("ASCII-8BIT")
+        gz = Zlib::GzipWriter.new(io)
+        gz.write(str)
+        gz.close
+        io.string
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,6 +70,7 @@ end
 
 require_relative "support/assert_helper"
 require_relative "support/braintrust_helper"
+require_relative "support/compression_helper"
 require_relative "support/fixture_helper"
 require_relative "support/log_helper"
 require_relative "support/mock_helper"
@@ -80,6 +81,7 @@ require_relative "support/tracing_helper"
 class Minitest::Test
   include ::Test::Support::AssertHelper
   include ::Test::Support::BraintrustHelper
+  include ::Test::Support::CompressionHelper
   include ::Test::Support::FixtureHelper
   include ::Test::Support::LogHelper
   include ::Test::Support::MockHelper


### PR DESCRIPTION
## Fix HTTP 303 redirect handling for large dataset responses

Fixes #101

### Problem

The Braintrust API returns HTTP 303 redirects to S3 presigned URLs when responses are large (e.g., dataset fetches via `POST /btql`). The SDK treated all non-2xx responses as errors, so these redirects raised exceptions like:

```
HTTP 303 for POST https://api.braintrust.dev/btql: See Other
```

### Solution

Extracted a new `Braintrust::Internal::Http` module with two composable utilities:

- **`Http.with_redirects(uri, request)`** — drop-in replacement for raw `Net::HTTP` request execution that follows HTTP redirects. Handles 301/302/303 (follow with GET), 307/308 (preserve method and body), strips `Authorization` headers on cross-host redirects (e.g., API → S3), and enforces a configurable max redirect limit.

- **`Http.decompress_response!(response)`** — decompresses response bodies based on `Content-Encoding` (gzip, x-gzip). No-op if uncompressed.

**The following HTTP call sites now use `with_redirects`:**

- `API::Datasets` — list, get, create, insert, fetch (fetch also calls `decompress_response!`)
- `API::Functions` — list, create, invoke, get, delete
- `API::Internal::Projects` — create
- `API::Internal::Experiments` — create
- `API::Internal::Auth` — login
- `Trace::Attachment` — from_url

#### Redirect handling

| Status | Before | After |
|--------|--------|-------|
| 301 Moved Permanently | Raised `Braintrust::Error` | Follow with GET |
| 302 Found | Raised `Braintrust::Error` | Follow with GET |
| 303 See Other | Raised `Braintrust::Error` | Follow with GET, strip auth on cross-host |
| 307 Temporary Redirect | Raised `Braintrust::Error` | Follow, preserving method and body |
| 308 Permanent Redirect | Raised `Braintrust::Error` | Follow, preserving method and body |
| gzip `Content-Encoding` | Not handled | Decompressed transparently |
