### PR TITLE
Add OTel Context metadata inheritance for auto-instrumented LLM spans

### DIFF
--- a/lib/braintrust/contrib/support/otel.rb
+++ b/lib/braintrust/contrib/support/otel.rb
@@ -7,15 +7,42 @@ module Braintrust
     module Support
       # OpenTelemetry utilities shared across all integrations.
       module OTel
+        METADATA_CONTEXT_KEY = "braintrust.metadata"
+
         # Helper to safely set a JSON attribute on a span
-        # Only sets the attribute if obj is present
+        # Only sets the attribute if obj is present.
+        # When setting "braintrust.metadata", automatically inherits metadata from the
+        # parent OTel Context so parent spans can propagate metadata to child LLM spans.
         # @param span [OpenTelemetry::Trace::Span] the span to set attribute on
         # @param attr_name [String] the attribute name (e.g., "braintrust.output_json")
         # @param obj [Object] the object to serialize to JSON
         # @return [void]
         def self.set_json_attr(span, attr_name, obj)
           return unless obj
+          inherit_context_metadata!(obj) if attr_name == METADATA_CONTEXT_KEY
           span.set_attribute(attr_name, JSON.generate(obj))
+        end
+
+        # Inherit metadata from the parent OTel Context into a child span's metadata hash.
+        # Parent metadata provides defaults; the child span's own metadata wins on key collisions.
+        # This enables parent spans (e.g. task spans) to propagate metadata like prompt origin
+        # to auto-instrumented LLM call spans.
+        # @param metadata [Hash] the child span's metadata hash (mutated in place)
+        # @return [void]
+        def self.inherit_context_metadata!(metadata)
+          return unless metadata.is_a?(Hash)
+
+          parent_metadata = OpenTelemetry::Context.current.value(METADATA_CONTEXT_KEY)
+          return unless parent_metadata.is_a?(Hash)
+
+          merged = parent_metadata.merge(metadata) { |_key, parent_val, child_val|
+            if parent_val.is_a?(Hash) && child_val.is_a?(Hash)
+              parent_val.merge(child_val)
+            else
+              child_val
+            end
+          }
+          metadata.replace(merged)
         end
       end
     end

--- a/test/braintrust/contrib/support/otel_test.rb
+++ b/test/braintrust/contrib/support/otel_test.rb
@@ -32,4 +32,88 @@ class Braintrust::Contrib::Support::OTelTest < Minitest::Test
 
     span.verify
   end
+
+  def test_set_json_attr_inherits_context_metadata_for_metadata_attr
+    parent_metadata = {"prompt_id" => "abc", "shared" => "parent"}
+    child_metadata = {"provider" => "openai", "shared" => "child"}
+
+    context = OpenTelemetry::Context.current.set_value("braintrust.metadata", parent_metadata)
+    OpenTelemetry::Context.with_current(context) do
+      span = Minitest::Mock.new
+      expected = JSON.generate({"prompt_id" => "abc", "shared" => "child", "provider" => "openai"})
+      span.expect(:set_attribute, nil, ["braintrust.metadata", expected])
+
+      Braintrust::Contrib::Support::OTel.set_json_attr(span, "braintrust.metadata", child_metadata)
+
+      span.verify
+    end
+  end
+
+  def test_set_json_attr_does_not_inherit_for_non_metadata_attrs
+    parent_metadata = {"prompt_id" => "abc"}
+    context = OpenTelemetry::Context.current.set_value("braintrust.metadata", parent_metadata)
+    OpenTelemetry::Context.with_current(context) do
+      span = Minitest::Mock.new
+      span.expect(:set_attribute, nil, ["braintrust.output", '{"foo":"bar"}'])
+
+      Braintrust::Contrib::Support::OTel.set_json_attr(span, "braintrust.output", {"foo" => "bar"})
+
+      span.verify
+    end
+  end
+
+  # --- .inherit_context_metadata! ---
+
+  def test_inherit_context_metadata_merges_parent_with_child_winning
+    parent_metadata = {"prompt_id" => "abc", "shared" => "parent"}
+    child_metadata = {"provider" => "openai", "shared" => "child"}
+
+    context = OpenTelemetry::Context.current.set_value("braintrust.metadata", parent_metadata)
+    OpenTelemetry::Context.with_current(context) do
+      Braintrust::Contrib::Support::OTel.inherit_context_metadata!(child_metadata)
+    end
+
+    assert_equal({"prompt_id" => "abc", "provider" => "openai", "shared" => "child"}, child_metadata)
+  end
+
+  def test_inherit_context_metadata_deep_merges_nested_hashes
+    parent_metadata = {"origin" => {"type" => "prompt", "id" => "abc", "version" => "1"}}
+    child_metadata = {"origin" => {"type" => "override"}}
+
+    context = OpenTelemetry::Context.current.set_value("braintrust.metadata", parent_metadata)
+    OpenTelemetry::Context.with_current(context) do
+      Braintrust::Contrib::Support::OTel.inherit_context_metadata!(child_metadata)
+    end
+
+    assert_equal({"origin" => {"type" => "override", "id" => "abc", "version" => "1"}}, child_metadata)
+  end
+
+  def test_inherit_context_metadata_noop_without_parent
+    child_metadata = {"provider" => "openai"}
+
+    Braintrust::Contrib::Support::OTel.inherit_context_metadata!(child_metadata)
+
+    assert_equal({"provider" => "openai"}, child_metadata)
+  end
+
+  def test_inherit_context_metadata_noop_for_non_hash_parent
+    context = OpenTelemetry::Context.current.set_value("braintrust.metadata", "not a hash")
+    OpenTelemetry::Context.with_current(context) do
+      child_metadata = {"provider" => "openai"}
+
+      Braintrust::Contrib::Support::OTel.inherit_context_metadata!(child_metadata)
+
+      assert_equal({"provider" => "openai"}, child_metadata)
+    end
+  end
+
+  def test_inherit_context_metadata_noop_for_non_hash_metadata
+    parent_metadata = {"prompt_id" => "abc"}
+    context = OpenTelemetry::Context.current.set_value("braintrust.metadata", parent_metadata)
+    OpenTelemetry::Context.with_current(context) do
+      # Should not raise
+      Braintrust::Contrib::Support::OTel.inherit_context_metadata!(nil)
+      Braintrust::Contrib::Support::OTel.inherit_context_metadata!("string")
+    end
+  end
 end


### PR DESCRIPTION
## Summary

When parent spans store metadata in the OTel Context (via the `braintrust.metadata` context key), auto-instrumented child LLM spans now automatically inherit that metadata. Child span metadata takes precedence on key collisions, with deep merge support for nested hashes.

This enables propagating metadata (e.g. prompt origin) from task-level spans to the auto-instrumented LLM call spans they contain, without requiring consumers to monkey-patch the SDK's instrumentation modules.

### How it works

- `Support::OTel.inherit_context_metadata!(metadata)` reads the `braintrust.metadata` key from the current OTel Context and merges it into the child span's metadata hash, with child keys winning on collisions
- This is called automatically from `Support::OTel.set_json_attr` whenever the attribute being set is `braintrust.metadata`, so all integrations (ruby-openai, openai, anthropic, ruby_llm) benefit without per-integration changes

### Use case

```ruby
# Parent task span sets metadata in OTel Context
tracer.in_span("My Task") do |span|
  metadata = { "prompt_id" => "abc", "prompt_version" => "42" }
  span.set_attribute("braintrust.metadata", metadata.to_json)
  
  context = OpenTelemetry::Context.current.set_value("braintrust.metadata", metadata)
  OpenTelemetry::Context.with_current(context) do
    # Auto-instrumented LLM call inherits prompt_id and prompt_version
    client.chat(parameters: { model: "gpt-4o", messages: [...] })
  end
end
```

## Test plan

- Added 7 new tests in `test/braintrust/contrib/support/otel_test.rb` covering:
  - [x] Parent metadata merges into child with child keys winning on collisions
  - [x] Deep merge of nested hash metadata
  - [x] No-op when no parent metadata exists in OTel context
  - [x] No-op when parent metadata is not a Hash
  - [x] No-op when child metadata is not a Hash (nil, string)
  - [x] Inheritance triggers only for `braintrust.metadata` attribute, not other attributes
  - [x] Integration with `set_json_attr` producing correct JSON output
- Full test suite passes: 1228 runs, 0 failures, 0 errors
- StandardRB linter passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)