### PR TITLE
Support parameters in remote evals

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This is the official Ruby SDK for [Braintrust](https://www.braintrust.dev), for 
   - [Attachments](#attachments)
   - [Viewing traces](#viewing-traces)
 - [Evals](#evals)
+  - [Tasks](#tasks)
   - [Datasets](#datasets)
   - [Scorers](#scorers)
   - [Dev Server](#dev-server)
@@ -261,6 +262,48 @@ Braintrust::Eval.run(
 
 See [eval.rb](./examples/eval.rb) for a full example.
 
+### Tasks
+
+Define the code being evaluated as a lambda or a class. Tasks receive `input:` as a keyword argument:
+
+```ruby
+# Lambda
+task = ->(input:) { classify(input) }
+
+# Class-based (auto-derives name from class: "food_classifier")
+class FoodClassifier
+  include Braintrust::Task
+
+  def call(input:)
+    classify(input)
+  end
+end
+```
+
+#### With parameters
+
+Tasks can accept `parameters:` as input to drive their behavior:
+
+```ruby
+task = ->(input:, parameters:) {
+  value = parameters["value"]
+  from_unit = parameters["to_unit"] || 'c'
+  to_unit = parameters["from_unit"] || 'f'
+
+  convert_temp(temperature: value, from_unit: from_unit , to_unit: to_unit)
+}
+
+Braintrust::Eval.run(
+  project: "my-project",
+  cases: [...],
+  task: task,
+  scorers: [...],
+  parameters: {"value" => 23.0}
+)
+```
+
+See [parameters.rb](./examples/eval/parameters.rb) for a full example.
+
 ### Datasets
 
 Use test cases from a Braintrust dataset:
@@ -389,6 +432,19 @@ Braintrust::Eval.run(
 ```
 
 See [trace_scoring.rb](./examples/eval/trace_scoring.rb) for a full example.
+
+#### Scorer parameters
+
+Scorers can also accept `parameters:` to use runtime configuration in their scoring logic. Like tasks, scorers that don't declare `parameters:` are unaffected:
+
+```ruby
+Braintrust::Scorer.new("threshold_match") do |expected:, output:, parameters:|
+  threshold = parameters["threshold"] || 0.8
+  similarity(output, expected) >= threshold ? 1.0 : 0.0
+end
+```
+
+See [parameters.rb](./examples/eval/parameters.rb) for a full example.
 
 ### Dev Server
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -30,6 +30,10 @@ BRAINTRUST_DEBUG=true ruby examples/login/login_basic.rb
 
 - **`login/login_basic.rb`**: Basic login example showing how to authenticate and retrieve organization information
 
+### Eval Examples
+
+- **`eval/parameters.rb`**: Use `parameters:` to configure task and scorer behavior at runtime — useful for remote evals run from the Braintrust Playground
+
 ### Dev Server Examples
 
 - **`server/eval.ru`**: Set up a dev server for remote evals — define evaluators (subclass or inline) and serve them via a Rack app. Start with: `bundle exec appraisal server rackup examples/server/eval.ru -p 8300 -o 0.0.0.0`

--- a/examples/eval/parameters.rb
+++ b/examples/eval/parameters.rb
@@ -1,0 +1,80 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Example: Using parameters to configure evaluation behavior
+#
+# This example demonstrates how to:
+# 1. Define a task that accepts `parameters:` for runtime configuration
+# 2. Run Eval.run with `parameters:` to control task behavior
+# 3. Use parameters in scorers for configurable scoring thresholds
+#
+# Parameters are passed as keyword arguments. Tasks and scorers that declare
+# `parameters:` in their signature receive them automatically. Those that
+# don't declare `parameters:` are unaffected — the SDK's KeywordFilter
+# strips unknown kwargs before calling.
+#
+# This is especially useful for remote evals run from the Braintrust Playground,
+# where the UI sends parameter values (e.g. model name, temperature) in the
+# request body.
+#
+# Usage:
+#   ruby examples/eval/parameters.rb
+
+require "bundler/setup"
+require "braintrust"
+require "braintrust/eval"
+
+Braintrust.init
+at_exit { OpenTelemetry.tracer_provider.shutdown }
+
+project_name = "ruby-sdk-examples"
+
+# --- Task with parameters ---
+#
+# The task receives `parameters:` as a keyword argument.
+# Here we use a "suffix" parameter to append to the output.
+task = ->(input:, parameters:) {
+  suffix = parameters["suffix"] || ""
+  input.upcase + suffix
+}
+
+# --- Scorer with parameters ---
+#
+# Scorers can also access parameters. Here we use a configurable
+# tolerance threshold for fuzzy matching.
+scorer = Braintrust::Scorer.new("exact_with_params") do |expected:, output:, parameters:|
+  threshold = parameters["threshold"] || 1.0
+  (output == expected) ? 1.0 : (1.0 - threshold)
+end
+
+# --- Run evaluation ---
+#
+# Pass `parameters:` to Eval.run. Both the task and scorer receive them.
+puts "Running evaluation with parameters: suffix='!', threshold=0.8"
+Braintrust::Eval.run(
+  project: project_name,
+  experiment: "parameters-demo",
+  cases: [
+    {input: "hello", expected: "HELLO!"},
+    {input: "world", expected: "WORLD!"}
+  ],
+  task: task,
+  scorers: [scorer],
+  parameters: {"suffix" => "!", "threshold" => 0.8}
+)
+
+# --- Run again with different parameters ---
+#
+# Same task and scorer, different behavior.
+puts "\nRunning again with parameters: suffix='?', threshold=0.5"
+Braintrust::Eval.run(
+  project: project_name,
+  experiment: "parameters-demo-v2",
+  cases: [
+    {input: "hello", expected: "HELLO?"},
+    {input: "world", expected: "WORLD?"}
+  ],
+  task: task,
+  scorers: [scorer],
+  parameters: {"suffix" => "?", "threshold" => 0.5}
+)

--- a/examples/server/eval.ru
+++ b/examples/server/eval.ru
@@ -44,10 +44,15 @@ class FoodClassifier < Braintrust::Eval::Evaluator
 end
 
 # Inline pattern: pass task and scorers as constructor arguments.
+# The task declares `parameters:` to receive runtime values from the Playground UI.
+# When run remotely, users can override max_length in the Playground.
 text_summarizer = Braintrust::Eval::Evaluator.new(
-  task: ->(input:) {
+  task: ->(input:, parameters:) {
+    max_length = parameters["max_length"] || 100
     words = input.to_s.split
-    words.first(10).join(" ") + ((words.length > 10) ? "..." : "")
+    summary = words.first(max_length).join(" ")
+    summary += "..." if words.length > max_length
+    summary
   },
   scorers: [
     Braintrust::Scorer.new("length_check") { |input:, output:|
@@ -55,7 +60,7 @@ text_summarizer = Braintrust::Eval::Evaluator.new(
     }
   ],
   parameters: {
-    "max_length" => {type: "number", default: 100, description: "Maximum summary length"}
+    "max_length" => {type: "number", default: 100, description: "Maximum number of words in summary"}
   }
 )
 

--- a/lib/braintrust/eval.rb
+++ b/lib/braintrust/eval.rb
@@ -105,6 +105,21 @@ module Braintrust
   #     scorers: [->(expected:, output:) { output == expected ? 1.0 : 0.0 }]
   #   )
   #
+  # @example Using parameters for configurable tasks
+  #   # Tasks and scorers that declare `parameters:` receive it automatically.
+  #   # Those that don't are unaffected — KeywordFilter strips unknown kwargs.
+  #   Braintrust::Eval.run(
+  #     project: "my-project",
+  #     experiment: "with-params",
+  #     cases: [{input: "hello", expected: "HELLO!"}],
+  #     task: ->(input:, parameters:) {
+  #       suffix = parameters["suffix"] || ""
+  #       input.upcase + suffix
+  #     },
+  #     scorers: [->(expected:, output:) { output == expected ? 1.0 : 0.0 }],
+  #     parameters: {"suffix" => "!"}
+  #   )
+  #
   # @example Using metadata and tags
   #   Braintrust::Eval.run(
   #     project: "my-project",
@@ -158,11 +173,15 @@ module Braintrust
       # @param quiet [Boolean] If true, suppress result output (default: false)
       # @param state [State, nil] Braintrust state (defaults to global state)
       # @param tracer_provider [TracerProvider, nil] OpenTelemetry tracer provider (defaults to global)
+      # @param project_id [String, nil] Project UUID (skips project creation when provided)
+      # @param parent [Hash, nil] Parent span context ({object_type:, object_id:, generation:})
+      # @param parameters [Hash, nil] Runtime parameters passed to task and scorers as a `parameters:` keyword argument
       # @return [Result]
       def run(task:, scorers:, project: nil, experiment: nil,
         cases: nil, dataset: nil, on_progress: nil,
         parallelism: 1, tags: nil, metadata: nil, update: false, quiet: false,
-        state: nil, tracer_provider: nil, project_id: nil, parent: nil)
+        state: nil, tracer_provider: nil, project_id: nil, parent: nil,
+        parameters: nil)
         # Validate required parameters
         validate_params!(task: task, scorers: scorers, cases: cases, dataset: dataset)
 
@@ -205,7 +224,8 @@ module Braintrust
           state: state,
           tracer_provider: tracer_provider,
           on_progress: on_progress,
-          parent: parent
+          parent: parent,
+          parameters: parameters
         )
         result = Runner.new(context).run(parallelism: parallelism)
 

--- a/lib/braintrust/eval/context.rb
+++ b/lib/braintrust/eval/context.rb
@@ -9,7 +9,7 @@ module Braintrust
     class Context
       attr_reader :task, :scorers, :cases, :experiment_id, :experiment_name,
         :project_id, :project_name, :state, :tracer_provider,
-        :on_progress, :parent_span_attr, :generation
+        :on_progress, :parent_span_attr, :generation, :parameters
 
       # @param task [Task] Normalized task wrapper
       # @param scorers [Array<Scorer>] Normalized scorer wrappers
@@ -23,9 +23,10 @@ module Braintrust
       # @param on_progress [Proc, nil] Callback invoked after each case completes, receiving a progress Hash
       # @param parent_span_attr [String, nil] Formatted parent span identifier ("type:id"), linking spans to a parent context
       # @param generation [Integer, nil] Generation number from the parent span context, used to link spans in a trace hierarchy
+      # @param parameters [Hash, nil] Runtime parameters passed to task and scorers as a `parameters:` keyword argument
       def initialize(task:, scorers:, cases:, experiment_id: nil, experiment_name: nil,
         project_id: nil, project_name: nil, state: nil, tracer_provider: nil,
-        on_progress: nil, parent_span_attr: nil, generation: nil)
+        on_progress: nil, parent_span_attr: nil, generation: nil, parameters: nil)
         @task = task
         @scorers = scorers
         @cases = cases
@@ -38,6 +39,7 @@ module Braintrust
         @on_progress = on_progress
         @parent_span_attr = parent_span_attr
         @generation = generation
+        @parameters = parameters
       end
 
       # Build a Context from raw user inputs.
@@ -53,17 +55,18 @@ module Braintrust
       # @param tracer_provider [#tracer, nil] OpenTelemetry tracer provider; defaults to global provider
       # @param on_progress [Proc, nil] Callback invoked after each case completes, receiving a progress Hash
       # @param parent [Hash, nil] Parent span info with keys :object_type, :object_id, and optionally :generation
+      # @param parameters [Hash, nil] Runtime parameters passed to task and scorers as a `parameters:` keyword argument
       # @return [Context]
       def self.build(task:, scorers:, cases:, experiment_id: nil, experiment_name: nil,
         project_id: nil, project_name: nil, state: nil, tracer_provider: nil,
-        on_progress: nil, parent: nil)
+        on_progress: nil, parent: nil, parameters: nil)
         Factory.new(
           state: state, tracer_provider: tracer_provider,
           project_id: project_id, project_name: project_name
         ).build(
           task: task, scorers: scorers, cases: cases,
           experiment_id: experiment_id, experiment_name: experiment_name,
-          on_progress: on_progress, parent: parent
+          on_progress: on_progress, parent: parent, parameters: parameters
         )
       end
 
@@ -90,7 +93,7 @@ module Braintrust
         # @param parent [Hash, nil] Parent span info with keys :object_type, :object_id, and optionally :generation
         # @return [Context]
         def build(task:, scorers:, cases:, experiment_id: nil, experiment_name: nil,
-          on_progress: nil, parent: nil)
+          on_progress: nil, parent: nil, parameters: nil)
           Context.new(
             task: normalize_task(task),
             scorers: normalize_scorers(scorers),
@@ -103,7 +106,8 @@ module Braintrust
             tracer_provider: @tracer_provider || OpenTelemetry.tracer_provider,
             on_progress: on_progress,
             parent_span_attr: resolve_parent_span_attr(parent),
-            generation: parent&.dig(:generation)
+            generation: parent&.dig(:generation),
+            parameters: parameters
           )
         end
 

--- a/lib/braintrust/eval/evaluator.rb
+++ b/lib/braintrust/eval/evaluator.rb
@@ -27,6 +27,18 @@ module Braintrust
     #       Braintrust::Scorer.new("exact_match") { |expected:, output:| output == expected ? 1.0 : 0.0 }
     #     ]
     #   )
+    #
+    # @example Remote eval with parameters (for Playground UI)
+    #   Braintrust::Eval::Evaluator.new(
+    #     task: ->(input:, parameters:) {
+    #       model = parameters["model"] || "gpt-4"
+    #       # Use model to generate response...
+    #     },
+    #     scorers: [Braintrust::Scorer.new("exact") { |expected:, output:| output == expected ? 1.0 : 0.0 }],
+    #     parameters: {
+    #       "model" => {type: "string", default: "gpt-4", description: "Model to use"}
+    #     }
+    #   )
     class Evaluator
       attr_accessor :task, :scorers, :parameters
 
@@ -64,13 +76,15 @@ module Braintrust
       def run(cases, on_progress: nil, quiet: false,
         project: nil, experiment: nil, project_id: nil,
         dataset: nil, scorers: nil, parent: nil,
-        state: nil, update: false, tracer_provider: nil)
+        state: nil, update: false, tracer_provider: nil,
+        parameters: nil)
         all_scorers = scorers ? self.scorers + scorers : self.scorers
         Braintrust::Eval.run(
           task: task, scorers: all_scorers, cases: cases, dataset: dataset,
           project: project, experiment: experiment, project_id: project_id,
           parent: parent, on_progress: on_progress, quiet: quiet,
-          state: state, update: update, tracer_provider: tracer_provider
+          state: state, update: update, tracer_provider: tracer_provider,
+          parameters: parameters
         )
       end
     end

--- a/lib/braintrust/eval/runner.rb
+++ b/lib/braintrust/eval/runner.rb
@@ -140,7 +140,8 @@ module Braintrust
 
           begin
             output = eval_context.task.call(
-              input: kase.input
+              input: kase.input,
+              parameters: eval_context.parameters || {}
             )
             set_json_attr(task_span, "braintrust.output_json", output)
             output
@@ -162,13 +163,15 @@ module Braintrust
           expected: kase.expected,
           output: kase.output,
           metadata: kase.metadata || {},
-          trace: kase.trace
+          trace: kase.trace,
+          parameters: eval_context.parameters || {}
         }
         scorer_input = {
           input: kase.input,
           expected: kase.expected,
           output: kase.output,
-          metadata: kase.metadata || {}
+          metadata: kase.metadata || {},
+          parameters: eval_context.parameters || {}
         }
 
         scorer_error = nil

--- a/lib/braintrust/server/services/eval_service.rb
+++ b/lib/braintrust/server/services/eval_service.rb
@@ -40,7 +40,8 @@ module Braintrust
             experiment_name: body["experiment_name"],
             remote_scorer_ids: resolve_remote_scorers(body["scores"]),
             parent: resolve_parent(body["parent"]),
-            project_id: body["project_id"]
+            project_id: body["project_id"],
+            parameters: resolve_parameters(body["parameters"], evaluator)
           }
         end
 
@@ -57,6 +58,7 @@ module Braintrust
           remote_scorer_ids = validated[:remote_scorer_ids]
           parent = validated[:parent]
           project_id = validated[:project_id]
+          parameters = validated[:parameters]
 
           state = build_state(auth)
 
@@ -89,6 +91,7 @@ module Braintrust
           }
           run_opts[:parent] = parent if parent
           run_opts[:scorers] = remote_scorer_ids if remote_scorer_ids
+          run_opts[:parameters] = parameters if parameters && !parameters.empty?
           run_opts[:dataset] = dataset if dataset
 
           if state
@@ -159,6 +162,15 @@ module Braintrust
         def current_evaluators
           return @evaluators.call if @evaluators.respond_to?(:call)
           @evaluators
+        end
+
+        # Merge request parameters with evaluator's parameter defaults.
+        # Request values override defaults. Returns a string-keyed Hash.
+        def resolve_parameters(raw_params, evaluator)
+          defaults = (evaluator.parameters || {}).to_h { |name, spec|
+            [name.to_s, spec.is_a?(Hash) ? (spec[:default] || spec["default"]) : nil]
+          }.compact
+          defaults.merge(raw_params || {})
         end
 
         # Resolve data source from the data field.

--- a/test/braintrust/eval/context_test.rb
+++ b/test/braintrust/eval/context_test.rb
@@ -325,6 +325,21 @@ class Braintrust::Eval::ContextTest < Minitest::Test
     assert_same fake_tp, ctx.tracer_provider
   end
 
+  # ============================================
+  # Context.build — parameters pass-through
+  # ============================================
+
+  def test_build_passes_through_parameters
+    params = {"model" => "gpt-4", "temperature" => 0.7}
+    ctx = build_context(parameters: params)
+    assert_equal params, ctx.parameters
+  end
+
+  def test_build_defaults_parameters_to_nil
+    ctx = build_context
+    assert_nil ctx.parameters
+  end
+
   private
 
   def build_context(task: ->(input:) { input }, scorers: [], cases: [{input: "a"}], **kwargs)

--- a/test/braintrust/eval/evaluator_test.rb
+++ b/test/braintrust/eval/evaluator_test.rb
@@ -230,4 +230,30 @@ class Braintrust::Eval::EvaluatorTest < Minitest::Test
 
     assert result.success?
   end
+
+  def test_run_forwards_parameters
+    evaluator = Braintrust::Eval::Evaluator.new(
+      task: ->(input:) { input.upcase },
+      scorers: [Braintrust::Scorer.new("s") { 1.0 }]
+    )
+
+    received_params = :not_called
+    Braintrust::Eval.stub(:run, ->(task:, scorers:, parameters:, **rest) {
+      received_params = parameters
+      Braintrust::Eval::Result.new(
+        experiment_id: nil, experiment_name: nil,
+        project_id: nil, project_name: nil,
+        permalink: nil, scores: {"s" => [1.0]}, errors: [], duration: 0.01
+      )
+    }) do
+      evaluator.run(
+        [{input: "hello"}],
+        parameters: {"model" => "gpt-4"},
+        quiet: true,
+        tracer_provider: @rig.tracer_provider
+      )
+    end
+
+    assert_equal({"model" => "gpt-4"}, received_params)
+  end
 end

--- a/test/braintrust/eval/runner_test.rb
+++ b/test/braintrust/eval/runner_test.rb
@@ -1906,4 +1906,162 @@ class Braintrust::Eval::RunnerTest < Minitest::Test
   def without_retry_sleep(&block)
     Braintrust::Internal::Retry.stub(:sleep, ->(_) {}, &block)
   end
+
+  # ============================================
+  # Runner — parameters support
+  # ============================================
+
+  def test_runner_passes_parameters_to_task
+    rig = setup_otel_test_rig
+    received_params = nil
+
+    context = Braintrust::Eval::Context.build(
+      task: ->(input:, parameters:) {
+        received_params = parameters
+        input.upcase
+      },
+      scorers: [Braintrust::Scorer.new("exact") { 1.0 }],
+      cases: [{input: "hello", expected: "HELLO"}],
+      experiment_id: "exp-123",
+      state: rig.state,
+      tracer_provider: rig.tracer_provider,
+      parameters: {"model" => "gpt-4", "temperature" => 0.7}
+    )
+
+    result = Braintrust::Eval::Runner.new(context).run
+    assert result.success?
+    assert_equal({"model" => "gpt-4", "temperature" => 0.7}, received_params)
+  end
+
+  def test_runner_task_without_parameters_kwarg_still_works
+    rig = setup_otel_test_rig
+
+    context = Braintrust::Eval::Context.build(
+      task: ->(input:) { input.upcase },
+      scorers: [Braintrust::Scorer.new("exact") { 1.0 }],
+      cases: [{input: "hello", expected: "HELLO"}],
+      experiment_id: "exp-123",
+      state: rig.state,
+      tracer_provider: rig.tracer_provider,
+      parameters: {"model" => "gpt-4"}
+    )
+
+    result = Braintrust::Eval::Runner.new(context).run
+    assert result.success?
+  end
+
+  def test_runner_passes_parameters_to_scorer
+    rig = setup_otel_test_rig
+    received_params = nil
+
+    context = Braintrust::Eval::Context.build(
+      task: ->(input:) { input.upcase },
+      scorers: [
+        Braintrust::Scorer.new("param_scorer") { |output:, parameters:|
+          received_params = parameters
+          1.0
+        }
+      ],
+      cases: [{input: "hello", expected: "HELLO"}],
+      experiment_id: "exp-123",
+      state: rig.state,
+      tracer_provider: rig.tracer_provider,
+      parameters: {"threshold" => 0.5}
+    )
+
+    result = Braintrust::Eval::Runner.new(context).run
+    assert result.success?
+    assert_equal({"threshold" => 0.5}, received_params)
+  end
+
+  def test_runner_scorer_without_parameters_kwarg_still_works
+    rig = setup_otel_test_rig
+
+    context = Braintrust::Eval::Context.build(
+      task: ->(input:) { input.upcase },
+      scorers: [
+        Braintrust::Scorer.new("exact") { |expected:, output:| (output == expected) ? 1.0 : 0.0 }
+      ],
+      cases: [{input: "hello", expected: "HELLO"}],
+      experiment_id: "exp-123",
+      state: rig.state,
+      tracer_provider: rig.tracer_provider,
+      parameters: {"model" => "gpt-4"}
+    )
+
+    result = Braintrust::Eval::Runner.new(context).run
+    assert result.success?
+    assert_equal({"exact" => [1.0]}, result.scores)
+  end
+
+  def test_runner_passes_empty_hash_when_no_parameters
+    rig = setup_otel_test_rig
+    received_params = nil
+
+    context = Braintrust::Eval::Context.build(
+      task: ->(input:, parameters:) {
+        received_params = parameters
+        input.upcase
+      },
+      scorers: [Braintrust::Scorer.new("exact") { 1.0 }],
+      cases: [{input: "hello", expected: "HELLO"}],
+      experiment_id: "exp-123",
+      state: rig.state,
+      tracer_provider: rig.tracer_provider
+    )
+
+    result = Braintrust::Eval::Runner.new(context).run
+    assert result.success?
+    assert_equal({}, received_params)
+  end
+
+  def test_runner_passes_parameters_to_callable_class_task
+    rig = setup_otel_test_rig
+    received_params = nil
+
+    callable = Class.new do
+      define_method(:call) do |input:, parameters:|
+        received_params = parameters
+        input.upcase
+      end
+    end.new
+
+    context = Braintrust::Eval::Context.build(
+      task: callable,
+      scorers: [Braintrust::Scorer.new("exact") { 1.0 }],
+      cases: [{input: "hello", expected: "HELLO"}],
+      experiment_id: "exp-123",
+      state: rig.state,
+      tracer_provider: rig.tracer_provider,
+      parameters: {"model" => "gpt-4"}
+    )
+
+    result = Braintrust::Eval::Runner.new(context).run
+    assert result.success?
+    assert_equal({"model" => "gpt-4"}, received_params)
+  end
+
+  def test_runner_parameters_with_parallelism
+    rig = setup_otel_test_rig
+    received = Queue.new
+
+    context = Braintrust::Eval::Context.build(
+      task: ->(input:, parameters:) {
+        received << parameters
+        input.upcase
+      },
+      scorers: [Braintrust::Scorer.new("exact") { 1.0 }],
+      cases: [{input: "a"}, {input: "b"}, {input: "c"}],
+      experiment_id: "exp-123",
+      state: rig.state,
+      tracer_provider: rig.tracer_provider,
+      parameters: {"model" => "gpt-4"}
+    )
+
+    result = Braintrust::Eval::Runner.new(context).run(parallelism: 3)
+    assert result.success?
+    params = [].tap { |a| a << received.pop until received.empty? }
+    assert_equal 3, params.length
+    assert(params.all? { |p| p == {"model" => "gpt-4"} })
+  end
 end

--- a/test/braintrust/eval_test.rb
+++ b/test/braintrust/eval_test.rb
@@ -1339,4 +1339,49 @@ class Braintrust::EvalTest < Minitest::Test
       end
     end
   end
+
+  # ============================================
+  # Parameters integration tests
+  # ============================================
+
+  def test_eval_run_with_parameters
+    VCR.use_cassette("eval/run_with_parameters") do
+      api = get_integration_test_api
+      experiments = Braintrust::API::Internal::Experiments.new(api.state)
+      result = nil
+
+      begin
+        # Task uses parameters to transform output
+        task = ->(input:, parameters:) {
+          suffix = parameters["suffix"] || ""
+          input.upcase + suffix
+        }
+
+        scorer = Braintrust::Scorer.new("exact") do |expected:, output:|
+          (output == expected) ? 1.0 : 0.0
+        end
+
+        result = Braintrust::Eval.run(
+          project: "ruby-sdk-test",
+          experiment: "test-ruby-sdk-parameters",
+          cases: [
+            {input: "hello", expected: "HELLO!"},
+            {input: "world", expected: "WORLD!"}
+          ],
+          task: task,
+          scorers: [scorer],
+          parameters: {"suffix" => "!"},
+          state: api.state,
+          tracer_provider: @rig.tracer_provider,
+          quiet: true
+        )
+
+        assert result.success?
+        assert_equal [], result.errors
+        assert_equal [1.0, 1.0], result.scores["exact"]
+      ensure
+        experiments.delete(id: result.experiment_id) if result&.experiment_id
+      end
+    end
+  end
 end

--- a/test/braintrust/server/rack/eval_endpoint_test.rb
+++ b/test/braintrust/server/rack/eval_endpoint_test.rb
@@ -162,6 +162,33 @@ module Braintrust
           assert_equal 400, last_response.status
         end
 
+        def test_parameters_forwarded_to_task
+          @evaluators["param-eval"] = test_evaluator(
+            task: ->(input:, parameters:) {
+              prefix = parameters["greeting"] || "hey"
+              "#{prefix} #{input}"
+            }
+          )
+
+          post_json "/eval", {
+            name: "param-eval",
+            data: {data: [{input: "world", expected: "hi world"}]},
+            parameters: {"greeting" => "hi"},
+            experiment_name: "test-experiment",
+            project_id: "proj-123",
+            parent: {object_type: "playground_id", object_id: "pg-123"}
+          }
+
+          assert_equal 200, last_response.status
+
+          events = parse_sse_events(last_response.body)
+          progress = events.find { |e|
+            e[:event] == "progress" && JSON.parse(e[:data]).dig("event") == "json_delta"
+          }
+          data = JSON.parse(progress[:data])
+          assert_equal "hi world", JSON.parse(data["data"])
+        end
+
         def test_rejects_get
           get "/eval"
           assert_equal 405, last_response.status

--- a/test/braintrust/server/services/eval_service_test.rb
+++ b/test/braintrust/server/services/eval_service_test.rb
@@ -174,6 +174,99 @@ module Braintrust
           assert_nil received_opts[:state]
         end
 
+        # --- validate: parameters ---
+
+        def test_validate_extracts_parameters_from_body
+          @evaluators["test-eval"] = test_evaluator(task: ->(input) { input })
+          result = service.validate({
+            "name" => "test-eval",
+            "data" => {"data" => [{"input" => "x"}]},
+            "parameters" => {"model" => "gpt-4", "temperature" => 0.7}
+          })
+
+          refute result.key?(:error)
+          assert_equal({"model" => "gpt-4", "temperature" => 0.7}, result[:parameters])
+        end
+
+        def test_validate_merges_parameters_with_evaluator_defaults
+          @evaluators["test-eval"] = test_evaluator(
+            task: ->(input) { input },
+            parameters: {
+              "model" => {type: "string", default: "gpt-3.5"},
+              "temperature" => {type: "number", default: 0.5}
+            }
+          )
+          result = service.validate({
+            "name" => "test-eval",
+            "data" => {"data" => [{"input" => "x"}]},
+            "parameters" => {"model" => "gpt-4"}
+          })
+
+          refute result.key?(:error)
+          assert_equal "gpt-4", result[:parameters]["model"]
+          assert_equal 0.5, result[:parameters]["temperature"]
+        end
+
+        def test_validate_returns_empty_parameters_when_none_provided
+          @evaluators["test-eval"] = test_evaluator(task: ->(input) { input })
+          result = service.validate({
+            "name" => "test-eval",
+            "data" => {"data" => [{"input" => "x"}]}
+          })
+
+          refute result.key?(:error)
+          assert_equal({}, result[:parameters])
+        end
+
+        def test_stream_passes_parameters_to_evaluator_run
+          received_opts = nil
+          spy = test_evaluator(task: ->(input) { input })
+          spy.define_singleton_method(:run) do |cases, **opts|
+            received_opts = opts
+            Braintrust::Eval::Result.new(
+              experiment_id: nil, experiment_name: nil,
+              project_id: nil, project_name: nil,
+              permalink: nil, scores: {}, errors: [], duration: 0.01
+            )
+          end
+
+          @evaluators["spy-eval"] = spy
+          s = service
+          validated = s.validate({
+            "name" => "spy-eval",
+            "data" => {"data" => [{"input" => "x"}]},
+            "parameters" => {"model" => "gpt-4"}
+          })
+
+          collect_streamed_events(s, validated, auth: true)
+
+          assert_equal({"model" => "gpt-4"}, received_opts[:parameters])
+        end
+
+        def test_stream_does_not_pass_empty_parameters
+          received_opts = nil
+          spy = test_evaluator(task: ->(input) { input })
+          spy.define_singleton_method(:run) do |cases, **opts|
+            received_opts = opts
+            Braintrust::Eval::Result.new(
+              experiment_id: nil, experiment_name: nil,
+              project_id: nil, project_name: nil,
+              permalink: nil, scores: {}, errors: [], duration: 0.01
+            )
+          end
+
+          @evaluators["spy-eval"] = spy
+          s = service
+          validated = s.validate({
+            "name" => "spy-eval",
+            "data" => {"data" => [{"input" => "x"}]}
+          })
+
+          collect_streamed_events(s, validated, auth: true)
+
+          refute received_opts.key?(:parameters)
+        end
+
         # --- build_state ---
 
         def test_build_state_returns_nil_for_non_hash_auth

--- a/test/fixtures/vcr_cassettes/eval/run_with_parameters.yml
+++ b/test/fixtures/vcr_cassettes/eval/run_with_parameters.yml
@@ -1,0 +1,269 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://www.braintrust.dev/api/apikey/login
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - www.braintrust.dev
+      Authorization:
+      - Bearer <BRAINTRUST_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Headers:
+      - X-CSRF-Token, X-Requested-With, Accept, Accept-Version, Content-Length, Content-MD5,
+        Content-Type, Date, X-Api-Version
+      Access-Control-Allow-Methods:
+      - GET,OPTIONS,PATCH,DELETE,POST,PUT
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - public, max-age=0, must-revalidate
+      Content-Length:
+      - '395'
+      Content-Security-Policy:
+      - 'script-src ''self'' ''unsafe-eval'' ''wasm-unsafe-eval'' ''strict-dynamic''
+        ''nonce-M2FkMzkyMGItMTNkMS00NDgyLTg5MmYtMWZkYWMyNjU0MTYw''  *.js.stripe.com
+        js.stripe.com maps.googleapis.com ; style-src ''self'' ''unsafe-inline'' *.braintrust.dev
+        btcm6qilbbhv4yi1.public.blob.vercel-storage.com fonts.googleapis.com www.gstatic.com
+        d4tuoctqmanu0.cloudfront.net; font-src ''self'' data: fonts.gstatic.com btcm6qilbbhv4yi1.public.blob.vercel-storage.com
+        cdn.jsdelivr.net d4tuoctqmanu0.cloudfront.net fonts.googleapis.com mintlify-assets.b-cdn.net
+        fonts.cdnfonts.com; object-src ''none''; base-uri ''self''; form-action ''self'';
+        frame-ancestors ''self''; worker-src ''self'' blob:; report-uri https://o4507221741076480.ingest.us.sentry.io/api/4507221754380288/security/?sentry_key=27fa5ac907cf7c6ce4a1ab2a03f805b4&sentry_environment=production&sentry_release=16;
+        report-to csp-endpoint-0'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 26 Mar 2026 16:18:02 GMT
+      Etag:
+      - '"12n7ok4b5phaz"'
+      Reporting-Endpoints:
+      - csp-endpoint-0="https://o4507221741076480.ingest.us.sentry.io/api/4507221754380288/security/?sentry_key=27fa5ac907cf7c6ce4a1ab2a03f805b4&sentry_environment=production&sentry_release=16"
+      Server:
+      - Vercel
+      Strict-Transport-Security:
+      - max-age=63072000
+      X-Clerk-Auth-Message:
+      - Invalid JWT form. A JWT consists of three parts separated by dots. (reason=token-invalid,
+        token-carrier=header)
+      X-Clerk-Auth-Reason:
+      - token-invalid
+      X-Clerk-Auth-Status:
+      - signed-out
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Matched-Path:
+      - "/api/apikey/login"
+      X-Nonce:
+      - M2FkMzkyMGItMTNkMS00NDgyLTg5MmYtMWZkYWMyNjU0MTYw
+      X-Vercel-Cache:
+      - MISS
+      X-Vercel-Id:
+      - cle1::iad1::zsshg-1774541882513-938767795d4c
+    body:
+      encoding: UTF-8
+      string: '{"org_info":[{"id":"5d7c97d7-fef1-4cb7-bda6-7e3756a0ca8e","name":"braintrustdata.com","api_url":"https://staging-api.braintrust.dev","git_metadata":{"fields":["commit","branch","tag","author_name","author_email","commit_message","commit_time","dirty"],"collect":"some"},"is_universal_api":true,"proxy_url":"https://staging-api.braintrust.dev","realtime_url":"wss://realtime.braintrustapi.com"}]}'
+  recorded_at: Thu, 26 Mar 2026 16:18:02 GMT
+- request:
+    method: post
+    uri: https://staging-api.braintrust.dev/v1/project
+    body:
+      encoding: UTF-8
+      string: '{"name":"ruby-sdk-test"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - staging-api.braintrust.dev
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <BRAINTRUST_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '255'
+      Connection:
+      - keep-alive
+      X-Amz-Cf-Pop:
+      - CMH68-P1
+      - CMH68-P1
+      Date:
+      - Thu, 26 Mar 2026 16:18:03 GMT
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Amzn-Requestid:
+      - 0c45d16f-46dd-4b4e-a1b9-d38718cb1ab6
+      X-Bt-Internal-Trace-Id:
+      - 69c55c3a000000004836d38690c01adc
+      X-Amz-Apigw-Id:
+      - a1tZQGLpoAMEYhg=
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"ff-6vJBGKzQtkVK0GxiGBpsJc6l6u8"
+      Access-Control-Expose-Headers:
+      - x-bt-cursor,x-bt-found-existing,x-bt-query-plan,x-bt-api-duration-ms,x-bt-brainstore-duration-ms
+      X-Amzn-Trace-Id:
+      - Root=1-69c55c3a-59e4bdda7294fee018de369c;Parent=26db5fe67a50ecfb;Sampled=0;Lineage=1:fc3b4ff1:0
+      X-Bt-Found-Existing:
+      - 'true'
+      Via:
+      - 1.1 b7f97186b1999ddac2896624abb211e4.cloudfront.net (CloudFront), 1.1 ade0cadf195b634f1ce60fe31eb474a2.cloudfront.net
+        (CloudFront)
+      X-Cache:
+      - Miss from cloudfront
+      X-Amz-Cf-Id:
+      - QF3U6glZ5mRLsgQFylfRGUo01DneDK9Zv79UeUhQ3ejEDlJCiMFXNA==
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"ac86d18e-af78-4caf-918d-b89ad108ec67","org_id":"5d7c97d7-fef1-4cb7-bda6-7e3756a0ca8e","name":"ruby-sdk-test","description":null,"created":"2025-10-22T03:32:12.324Z","deleted_at":null,"user_id":"f2ddc4e6-a51a-4a60-9734-9af4ea05c6ef","settings":null}'
+  recorded_at: Thu, 26 Mar 2026 16:18:03 GMT
+- request:
+    method: post
+    uri: https://staging-api.braintrust.dev/v1/experiment
+    body:
+      encoding: UTF-8
+      string: '{"project_id":"ac86d18e-af78-4caf-918d-b89ad108ec67","ensure_new":true,"name":"test-ruby-sdk-parameters"}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - staging-api.braintrust.dev
+      Content-Type:
+      - application/json
+      Authorization:
+      - Bearer <BRAINTRUST_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '435'
+      Connection:
+      - keep-alive
+      X-Amz-Cf-Pop:
+      - CMH68-P1
+      - CMH68-P1
+      Date:
+      - Thu, 26 Mar 2026 16:18:03 GMT
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Amzn-Requestid:
+      - e34b0af4-7a1a-4be9-a06d-5682cfe0db85
+      X-Bt-Internal-Trace-Id:
+      - 69c55c3b0000000056c4c5907b1021fe
+      X-Amz-Apigw-Id:
+      - a1tZSFfcoAMEBFQ=
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"1b3-e9902DkgGn59zhHGLbfc2vRo2AM"
+      Access-Control-Expose-Headers:
+      - x-bt-cursor,x-bt-found-existing,x-bt-query-plan,x-bt-api-duration-ms,x-bt-brainstore-duration-ms
+      X-Amzn-Trace-Id:
+      - Root=1-69c55c3b-3b0ddb1a04dc8c11176a1703;Parent=394302ef5425eecf;Sampled=0;Lineage=1:fc3b4ff1:0
+      Via:
+      - 1.1 597391769ad998307dcc74a3c790e7c6.cloudfront.net (CloudFront), 1.1 d250acc8f0df4d0f6cf0c8da374c8b8e.cloudfront.net
+        (CloudFront)
+      X-Cache:
+      - Miss from cloudfront
+      X-Amz-Cf-Id:
+      - pJ-CD50hGlADYHZICL2laKuH3n48hd4fiuMM-rBalZU8V0W3GHsWkQ==
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"cf0493d6-32e5-446d-afdd-aff99dd0b7a4","project_id":"ac86d18e-af78-4caf-918d-b89ad108ec67","name":"test-ruby-sdk-parameters","description":null,"created":"2026-03-26T16:18:03.214Z","repo_info":null,"commit":null,"base_exp_id":null,"deleted_at":null,"dataset_id":null,"dataset_version":null,"parameters_id":null,"parameters_version":null,"public":false,"user_id":"c755328d-f64a-4737-a984-e83c088cd9f7","metadata":null,"tags":null}'
+  recorded_at: Thu, 26 Mar 2026 16:18:03 GMT
+- request:
+    method: delete
+    uri: https://staging-api.braintrust.dev/v1/experiment/cf0493d6-32e5-446d-afdd-aff99dd0b7a4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - staging-api.braintrust.dev
+      Authorization:
+      - Bearer <BRAINTRUST_API_KEY>
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '457'
+      Connection:
+      - keep-alive
+      X-Amz-Cf-Pop:
+      - CMH68-P1
+      - CMH68-P1
+      Date:
+      - Thu, 26 Mar 2026 16:18:03 GMT
+      Access-Control-Allow-Credentials:
+      - 'true'
+      X-Amzn-Requestid:
+      - fc8cdc56-3942-4bb9-822e-0808b68cc6d3
+      X-Bt-Internal-Trace-Id:
+      - 69c55c3b0000000048a618ffbf326592
+      X-Amz-Apigw-Id:
+      - a1tZWHcooAMEHCA=
+      Vary:
+      - Origin, Accept-Encoding
+      Etag:
+      - W/"1c9-HlESAHH2oC57Uq8AhF38PzEAr8I"
+      Access-Control-Expose-Headers:
+      - x-bt-cursor,x-bt-found-existing,x-bt-query-plan,x-bt-api-duration-ms,x-bt-brainstore-duration-ms
+      X-Amzn-Trace-Id:
+      - Root=1-69c55c3b-04d749f5333c44275abeab04;Parent=68b9b4af224fd201;Sampled=0;Lineage=1:fc3b4ff1:0
+      Via:
+      - 1.1 597391769ad998307dcc74a3c790e7c6.cloudfront.net (CloudFront), 1.1 ff2cda2997d759f25d189d4bd5288a18.cloudfront.net
+        (CloudFront)
+      X-Cache:
+      - Miss from cloudfront
+      X-Amz-Cf-Id:
+      - cGyBrWL1Zcw_f5uU7Ozazd-v8u2-76kAuJltipwF7IcQlP7l1GlQDQ==
+    body:
+      encoding: ASCII-8BIT
+      string: '{"id":"cf0493d6-32e5-446d-afdd-aff99dd0b7a4","project_id":"ac86d18e-af78-4caf-918d-b89ad108ec67","name":"test-ruby-sdk-parameters","description":null,"created":"2026-03-26T16:18:03.214Z","repo_info":null,"commit":null,"base_exp_id":null,"deleted_at":"2026-03-26T16:18:03.707Z","dataset_id":null,"dataset_version":null,"parameters_id":null,"parameters_version":null,"public":false,"user_id":"c755328d-f64a-4737-a984-e83c088cd9f7","metadata":null,"tags":null}'
+  recorded_at: Thu, 26 Mar 2026 16:18:03 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
When running evaluations from the Braintrust Playground, users can now configure task behavior at runtime by passing parameters through the UI.

### How it works

Tasks and scorers that declare a `parameters:` keyword argument receive runtime values automatically:

```ruby
task = ->(input:, parameters:) {
  model = parameters["model"] || "gpt-4"
  temperature = parameters["temperature"] || 0.7
  call_llm(model: model, temperature: temperature, prompt: input)
}

Braintrust::Eval.run(
  project: "my-project",
  cases: [...],
  task: task,
  scorers: [...],
  parameters: {"model" => "gpt-4o", "temperature" => 0.3}
)
```

Existing tasks and scorers that don't use `parameters:` continue to work unchanged -- unknown keyword arguments are filtered out automatically.

### Dev server / Playground integration

Evaluators can declare parameter definitions so the Playground UI knows what parameters are available and their defaults:

```ruby
Braintrust::Eval::Evaluator.new(
  task: ->(input:, parameters:) {
    model = parameters["model"] || "gpt-4"
    call_llm(model: model, prompt: input)
  },
  scorers: [...],
  parameters: {
    "model" => {type: "string", default: "gpt-4", description: "Model to use"}
  }
)
```

When users override parameter values in the Playground, those values are merged with the evaluator's defaults and passed through to the task and scorers.

Closes #122
