### PR TITLE
fix(deps): allow openssl 4.x for compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    braintrust (0.3.1)
+    braintrust (0.3.2)
       logger (>= 1.0)
       openssl (>= 3.3.1, < 5.0)
       opentelemetry-exporter-otlp (~> 0.28)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     braintrust (0.3.1)
       logger (>= 1.0)
-      openssl (~> 3.3.1)
+      openssl (>= 3.3.1, < 5.0)
       opentelemetry-exporter-otlp (~> 0.28)
       opentelemetry-sdk (~> 1.3)
 

--- a/braintrust.gemspec
+++ b/braintrust.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |spec|
   # that occur with OpenSSL 3.6 + Ruby (certificate verify failed: unable to get certificate CRL).
   # See: https://github.com/ruby/openssl/issues/949
   # This dependency may be removable in future Ruby versions once the fix is widely available.
-  spec.add_runtime_dependency "openssl", "~> 3.3.1"
+  spec.add_runtime_dependency "openssl", ">= 3.3.1", "< 5.0"
 end

--- a/lib/braintrust/version.rb
+++ b/lib/braintrust/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Braintrust
-  VERSION = "0.3.1"
+  VERSION = "0.3.2"
 end


### PR DESCRIPTION
Widen the openssl dependency from ~> 3.3.1 (which caps at < 3.4.0) to >= 3.3.1, < 5.0.

The SDK does not use any openssl APIs directly. The dependency exists only to ensure the macOS CRL verification bugfix from 3.3.1+ is present.

The previous constraint blocked users on openssl 4.0.

This PR also bumps the version so we can do a release immediately after it is merged.

Fixes #144