### PR TITLE
Fix OpenSSL mismatch vs Ruby 3.4 default causing build failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up language runtime
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
-          ruby-version: '3.4'
+          ruby-version: '4.0'
           bundler-cache: true
 
       - name: Read version
@@ -128,7 +128,7 @@ jobs:
       - name: Set up language runtime
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
-          ruby-version: '3.4'
+          ruby-version: '4.0'
           bundler-cache: true
 
       - name: Publish package with attestation

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in braintrust.gemspec
 gemspec
 
+# Pin openssl to the version bundled with the release runner (Ruby 4.0 ships 4.0.0).
+# Keeps the CI lockfile in sync with the runner's default gem to avoid bundler
+# activation conflicts. Update this when the ruby-version in release workflows changes.
+# Does not affect gem consumers — they use the gemspec constraint (>= 3.3.1).
+gem "openssl", "4.0.0"
+
 # Development dependencies
 gem "appraisal", "~> 2.5"
 gem "climate_control", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     minitest-stub-const (0.6)
-    openssl (3.3.2)
+    openssl (4.0.0)
     opentelemetry-api (1.7.0)
     opentelemetry-common (0.23.0)
       opentelemetry-api (~> 1.0)
@@ -142,6 +142,7 @@ DEPENDENCIES
   minitest (~> 5.0)
   minitest-reporters (~> 1.6)
   minitest-stub-const (~> 0.6)
+  openssl (= 4.0.0)
   rake (~> 13.0)
   simplecov (~> 0.22)
   standard (~> 1.0)
@@ -150,4 +151,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-  4.0.8
+   4.0.8

--- a/test/support/provider_helper.rb
+++ b/test/support/provider_helper.rb
@@ -5,14 +5,16 @@ module Test
       # Uses real key for recording, fake key for playback
       # @return [String] API key
       def get_anthropic_key
-        ENV["ANTHROPIC_API_KEY"] || "sk-ant-test-key-for-vcr"
+        key = ENV["ANTHROPIC_API_KEY"]
+        (key && !key.empty?) ? key : "sk-ant-test-key-for-vcr"
       end
 
       # Get OpenAI API key for tests
       # Uses real key for recording, fake key for playback
       # @return [String] API key
       def get_openai_key
-        ENV["OPENAI_API_KEY"] || "sk-test-key-for-vcr"
+        key = ENV["OPENAI_API_KEY"]
+        (key && !key.empty?) ? key : "sk-test-key-for-vcr"
       end
     end
   end


### PR DESCRIPTION
## Problem

We specified `openssl` in the gemspec, which happens to be a default gem packaged with Ruby.

During our build/release process, if Ruby uses/loads `openssl` with `RUBYOPT` before Bundler, its possible to have an "already loaded" version mismatch where the default gem version doesn't match the one installed by Bundler. This leads to build failures.

## Solution

Bump our CI Ruby version to 4.0 and pin our `Gemfile` to a version of `openssl` that specifically matches a known version of the Ruby runner in CI. This only affects our local build tooling (doesn't prevent users from using newer `openssl` versions), but does require us to keep this in sync with our Ruby version used in CI.