### PR TITLE
Fix gem build pkg dir

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
           bundler-cache: true
 
       - name: Publish package with attestation
-        uses: rubygems/release-gem@6317d8d1f7e28c24d28f6eff169ea854948bd9f7 # v1.2.0
+        uses: rubygems/release-gem@052cc82692552de3ef2b81fd670e41d13cba8092 # v1.4.0
         with:
           await-release: ${{ inputs.dry_run && 'false' || 'true' }}
           setup-trusted-publisher: ${{ inputs.dry_run && 'false' || 'true' }}

--- a/Rakefile
+++ b/Rakefile
@@ -67,7 +67,12 @@ end
 
 desc "Build the gem"
 task build: [:clean] do
+  # Output to pkg/ (Bundler convention). rubygems/release-gem awaits pkg/*.gem
+  # after pushing, so the gem must land there — not the repo root.
+  require_relative "lib/braintrust/version"
   sh "gem build braintrust.gemspec"
+  mkdir_p "pkg"
+  mv "braintrust-#{Braintrust::VERSION}.gem", "pkg/"
 end
 
 desc "Generate YARD documentation"
@@ -200,7 +205,7 @@ end
 # Release tasks
 namespace :release do
   task publish: [:lint, :build] do
-    gem_files = FileList["braintrust-*.gem"]
+    gem_files = FileList["pkg/braintrust-*.gem"]
     if gem_files.empty?
       puts "Error: No gem file found. Build task should have created it."
       exit 1


### PR DESCRIPTION
- Fixes `No such file or directory @ rb_sysopen - pkg/*.gem` error during releases
- Bumps `rubygems/release-gem` SHA to use newer version of Node