### PR TITLE
Skip per-case force_flush when no scorer/classifier uses trace:

### DIFF
--- a/lib/braintrust/eval/runner.rb
+++ b/lib/braintrust/eval/runner.rb
@@ -30,6 +30,8 @@ module Braintrust
         # Mutexes for thread-safe result collection
         @score_mutex = Mutex.new
         @classification_mutex = Mutex.new
+
+        @needs_trace = (eval_context.scorers + eval_context.classifiers).any? { |c| callable_wants_trace?(c) }
       end
 
       # Run evaluation and return Result
@@ -108,9 +110,13 @@ module Braintrust
             next
           end
 
-          # Flush spans so they're queryable via BTQL, then build trace
-          eval_context.tracer_provider.force_flush if eval_context.tracer_provider.respond_to?(:force_flush)
-          kase.trace = build_trace(eval_span)
+          # Flush spans so they're queryable via BTQL, then build trace — only when a
+          # scorer/classifier actually declared `trace:`, since the synchronous flush
+          # is a real per-case network wait (see #210).
+          if @needs_trace
+            eval_context.tracer_provider.force_flush if eval_context.tracer_provider.respond_to?(:force_flush)
+            kase.trace = build_trace(eval_span)
+          end
 
           # Run scorers
           begin
@@ -227,6 +233,17 @@ module Braintrust
           record_span_error(score_span, e, "ScorerError")
           raise
         end
+      end
+
+      # Whether a callable's declared parameters include `trace:`, or accept
+      # arbitrary kwargs (**kwargs) and so might use it. KeywordFilter already
+      # relies on #call_parameters for this same introspection.
+      # @param callable [Scorer, Classifier] a scorer or classifier instance
+      # @return [Boolean]
+      def callable_wants_trace?(callable)
+        return true unless callable.respond_to?(:call_parameters)
+
+        callable.call_parameters.any? { |type, name| name == :trace || type == :keyrest }
       end
 
       # Build a lazy Trace for a case, backed by BTQL.

--- a/test/braintrust/eval/runner_test.rb
+++ b/test/braintrust/eval/runner_test.rb
@@ -1301,6 +1301,58 @@ class Braintrust::Eval::RunnerTest < Minitest::Test
     end
   end
 
+  def test_force_flush_skipped_when_no_scorer_wants_trace
+    rig = setup_otel_test_rig
+    flush_calls = 0
+    rig.tracer_provider.stub(:force_flush, -> { flush_calls += 1 }) do
+      scorer = Braintrust::Scorer.new("simple") { |output:, expected:| (output == expected) ? 1.0 : 0.0 }
+
+      context = Braintrust::Eval::Context.build(
+        task: ->(input:) { input.upcase },
+        scorers: [scorer],
+        cases: [{input: "hello", expected: "HELLO"}, {input: "world", expected: "WORLD"}],
+        experiment_id: "exp-123",
+        experiment_name: "test-experiment",
+        project_id: "proj-456",
+        project_name: "test-project",
+        state: rig.state,
+        tracer_provider: rig.tracer_provider
+      )
+      runner = Braintrust::Eval::Runner.new(context)
+      result = runner.run
+
+      assert result.success?
+    end
+
+    assert_equal 0, flush_calls
+  end
+
+  def test_force_flush_still_happens_when_a_scorer_wants_trace
+    rig = setup_otel_test_rig
+    flush_calls = 0
+    rig.tracer_provider.stub(:force_flush, -> { flush_calls += 1 }) do
+      scorer = Braintrust::Scorer.new("trace_reader") { |output:, trace:| 1.0 }
+
+      context = Braintrust::Eval::Context.build(
+        task: ->(input:) { input.upcase },
+        scorers: [scorer],
+        cases: [{input: "hello"}, {input: "world"}],
+        experiment_id: "exp-123",
+        experiment_name: "test-experiment",
+        project_id: "proj-456",
+        project_name: "test-project",
+        state: rig.state,
+        tracer_provider: rig.tracer_provider
+      )
+      runner = Braintrust::Eval::Runner.new(context)
+      result = runner.run
+
+      assert result.success?
+    end
+
+    assert_equal 2, flush_calls
+  end
+
   # ============================================
   # Runner#run tests - structured scorer returns
   # ============================================


### PR DESCRIPTION
Fixes #210

## What

`Runner#run_eval_case` calls `eval_context.tracer_provider.force_flush` synchronously after every case, unconditionally, before running scorers/classifiers. This exists so a `trace:`-consuming scorer/classifier can BTQL-query that case's spans immediately with a freshness guarantee - but it runs even when nothing in the eval declares `trace:` at all.

## Impact (see #210 for full numbers)

Measured 10-25s+ per `force_flush` call against a ~139-case eval with no `trace:`-consuming scorers, dwarfing typical per-case task/scorer time. Increasing `parallelism` didn't help (one flush got slower, 48s, under concurrency).

## Fix

`Scorer`/`Classifier` already expose `#call_parameters` for `KeywordFilter`'s own kwarg-filtering. This reuses that same introspection: `Runner#initialize` computes once whether any registered scorer or classifier declares `trace:` (or accepts arbitrary `**kwargs`, which might use it), and the existing flush/`build_trace` call is skipped entirely when nothing does.

Nothing about the async `BatchSpanProcessor` export path changes - spans still export every ~5s regardless, and the SDK's own `at_exit` flush still guarantees final delivery. This only removes the synchronous per-case wait for evals that never look at `trace:`.

## Testing

- All existing tests pass, including the `trace:`-behavior tests in `runner_test.rb` (`test_scorer_declaring_trace_receives_eval_trace`, `test_trace_works_with_parallelism`, etc.) - none of them changed behavior, since they all declare `trace:` and are correctly detected as needing it.
- Added two new tests asserting the actual optimization: `force_flush` is not called when no scorer declares `trace:`, and still is called (once per case) when one does.
- Full suite: `1302 runs, 1978 assertions, 0 failures, 0 errors` (plus the 2 new tests).
- `standardrb` clean on both changed files.

Open to a different shape here (e.g. an explicit opt-out flag instead of auto-detection) if that's preferred - wanted to lead with a working reference implementation since I already had the repro in hand.